### PR TITLE
Update CustomerCard logic and rename HelpList

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -5,19 +5,20 @@ import seedu.address.model.Model;
 /**
  * Format full help instructions for every command for display.
  */
-public class HelpListCommand extends Command {
+public class HelpCommand extends Command {
 
-    public static final String COMMAND_WORD = "helplist"; //
+    public static final String COMMAND_WORD = "help"; //
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_HELP_MESSAGE = "List of Commands: \n"
         + "1. add - Enter a reservation \n"
-        + "2. delete - Delete a reservation \n "
-        + "3. show - Display reservation details \n "
-        + "4. view_schedule - Check the schedule of reservations \n "
-        + "5. list - Display the available commands \n";
+        + "2. delete - Delete a reservation \n"
+        + "3. show - Display reservation details \n"
+        + "4. list - Display a list of all reservations \n"
+        + "5. help - Display the available commands \n"
+        + "6. find - Finds a reservation by name \n";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -14,7 +14,6 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all customers";
 
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,7 +15,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpListCommand;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -41,7 +41,7 @@ public class AddressBookParser {
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpListCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -75,8 +75,8 @@ public class AddressBookParser {
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 
-        case HelpListCommand.COMMAND_WORD:
-            return new HelpListCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
 
         case ShowCommand.COMMAND_WORD:
             return new ShowCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,4 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DATE_TIME = new Prefix("d/");
     public static final Prefix PREFIX_NUMBER_OF_DINERS = new Prefix("x/");
-
-
 }

--- a/src/main/java/seedu/address/ui/CustomerCard.java
+++ b/src/main/java/seedu/address/ui/CustomerCard.java
@@ -1,10 +1,7 @@
 package seedu.address.ui;
 
-import java.util.Comparator;
-
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.customer.Customer;
@@ -33,17 +30,9 @@ public class CustomerCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label phone;
-    @FXML
-    private Label address;
-    @FXML
-    private Label email;
-    @FXML
     private Label diners;
     @FXML
     private Label dateTime;
-    @FXML
-    private FlowPane tags;
 
     /**
      * Creates a {@code CustomerCode} with the given {@code Customer} and index to display.
@@ -53,13 +42,7 @@ public class CustomerCard extends UiPart<Region> {
         this.customer = customer;
         id.setText(displayedIndex + ". ");
         name.setText(customer.getName().fullName);
-        phone.setText(customer.getPhone().value);
-        address.setText(customer.getAddress().value);
-        email.setText(customer.getEmail().value);
-        diners.setText(customer.getDiners().value);
+        diners.setText(customer.getDiners().value + " Diners");
         dateTime.setText(customer.getDateTime().toString());
-        customer.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -13,13 +13,13 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpListWindow extends UiPart<Stage> {
+public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL =
         "https://github.com/AY2425S2-CS2103-F08-1/tp/blob/master/docs/UserGuide.md";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
-    private static final Logger logger = LogsCenter.getLogger(HelpListWindow.class);
+    private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
     @FXML
@@ -33,7 +33,7 @@ public class HelpListWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpListWindow(Stage root) {
+    public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -41,7 +41,7 @@ public class HelpListWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpListWindow() {
+    public HelpWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -33,7 +33,7 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private CustomerListPanel customerListPanel;
     private ResultDisplay resultDisplay;
-    private HelpListWindow helpListWindow;
+    private HelpWindow helpWindow;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -65,7 +65,7 @@ public class MainWindow extends UiPart<Stage> {
 
         setAccelerators();
 
-        helpListWindow = new HelpListWindow();
+        helpWindow = new HelpWindow();
     }
 
     public Stage getPrimaryStage() {
@@ -140,10 +140,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleHelp() {
-        if (!helpListWindow.isShowing()) {
-            helpListWindow.show();
+        if (!helpWindow.isShowing()) {
+            helpWindow.show();
         } else {
-            helpListWindow.focus();
+            helpWindow.focus();
         }
     }
 

--- a/src/main/resources/view/CustomerListCard.fxml
+++ b/src/main/resources/view/CustomerListCard.fxml
@@ -28,9 +28,6 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="diners" styleClass="cell_small_label" text="\$diners" />
       <Label fx:id="dateTime" styleClass="cell_small_label" text="\$dateTime" />
     </VBox>

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -1,20 +1,20 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.HelpListCommand.SHOWING_HELP_MESSAGE;
+import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
-public class HelpListCommandTest {
+public class HelpCommandTest {
     private Model model = new ModelManager();
     private Model expectedModel = new ModelManager();
 
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpListCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,7 +19,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpListCommand;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.customer.Customer;
@@ -77,8 +77,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpListCommand.COMMAND_WORD) instanceof HelpListCommand);
-        assertTrue(parser.parseCommand(HelpListCommand.COMMAND_WORD + " 3") instanceof HelpListCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-            HelpListCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
+            HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
     }
 
     @Test


### PR DESCRIPTION
This PR modifies the customer List UI (customerCard) to only display the customer's name, number of dinners, date, removing unnecessary fields such as address, email and phone number

It also modifies the HelpListCommand to Help and updated the help description to include the correct list of commands

#63 