### PR TITLE
Fix List command bug and update UG & DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -143,16 +143,17 @@ Actor: Restaurant Manager, ReserveMate
 
 **Extensions**
 * 1a. The index is invalid.
+
   * 1a1. ReserveMate prompts the user to enter a valid index.
 
     Use case resumes at step 1.
 
 
-**Use case: UC05 - View Schedule**
+**Use case: UC05 - View Reservations**
 
 **MSS**
 
-1.  User requests to view schedule.
+1.  User requests to view all reservations.
 2.  ReserveMate retrieves and displays all existing reservations.
 
     Use case ends.
@@ -167,7 +168,10 @@ Actor: Restaurant Manager, ReserveMate
 
 * 2a. The list is empty.
 
-  Use case ends.
+  * 2a1. ReserveMate shows an error message.
+
+    Use case ends.
+
 
 **Use case: UC06 - Find Reservation by Name**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -100,6 +100,9 @@ Shows a list of all customers in the address book.
 
 Format: `list`
 
+Examples:
+* `list`
+
 ### Editing a reservation : `edit`
 
 Edits an existing reservation in ReserveMate.

--- a/src/main/java/seedu/reserve/logic/Messages.java
+++ b/src/main/java/seedu/reserve/logic/Messages.java
@@ -19,6 +19,9 @@ public class Messages {
     public static final String MESSAGE_RESERVATIONS_LISTED_OVERVIEW = "%1$d reservations listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_EMPTY_RESERVATION_LIST =
+            "No reservations found. Use the 'add' command to create a reservation\n"
+                    + "or 'help' to view all commands.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/reserve/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/ListCommand.java
@@ -3,7 +3,12 @@ package seedu.reserve.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.reserve.model.Model.PREDICATE_SHOW_ALL_RESERVATIONS;
 
+import java.util.List;
+
+import seedu.reserve.logic.Messages;
+import seedu.reserve.logic.commands.exceptions.CommandException;
 import seedu.reserve.model.Model;
+import seedu.reserve.model.reservation.Reservation;
 
 /**
  * Lists all reservations in the reservation book to the user.
@@ -15,8 +20,15 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all reservations";
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        List<Reservation> lastShownList = model.getFilteredReservationList();
+
+        if (lastShownList.isEmpty()) {
+            throw new CommandException(Messages.MESSAGE_EMPTY_RESERVATION_LIST);
+        }
+
         model.updateFilteredReservationList(PREDICATE_SHOW_ALL_RESERVATIONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/test/java/seedu/reserve/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/reserve/logic/LogicManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.reserve.logic.commands.AddCommand;
 import seedu.reserve.logic.commands.CommandResult;
+import seedu.reserve.logic.commands.HelpCommand;
 import seedu.reserve.logic.commands.ListCommand;
 import seedu.reserve.logic.commands.exceptions.CommandException;
 import seedu.reserve.logic.parser.exceptions.ParseException;
@@ -65,11 +66,7 @@ public class LogicManagerTest {
         assertCommandException(deleteCommand, MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
     }
 
-    @Test
-    public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
-    }
+
 
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
@@ -100,6 +97,12 @@ public class LogicManagerTest {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);
+    }
+
+    @Test
+    public void execute_validCommand_success() throws Exception {
+        String helpcommand = HelpCommand.COMMAND_WORD;
+        assertCommandSuccess(helpcommand, HelpCommand.SHOWING_HELP_MESSAGE, model);
     }
 
     /**

--- a/src/test/java/seedu/reserve/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/reserve/logic/LogicManagerTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.reserve.logic.commands.AddCommand;
 import seedu.reserve.logic.commands.CommandResult;
 import seedu.reserve.logic.commands.HelpCommand;
-import seedu.reserve.logic.commands.ListCommand;
 import seedu.reserve.logic.commands.exceptions.CommandException;
 import seedu.reserve.logic.parser.exceptions.ParseException;
 import seedu.reserve.model.Model;

--- a/src/test/java/seedu/reserve/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/ListCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.reserve.logic.commands;
 
+import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.reserve.logic.commands.CommandTestUtil.showCustomerAtIndex;
 import static seedu.reserve.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
@@ -8,6 +9,7 @@ import static seedu.reserve.testutil.TypicalReservation.getTypicalReserveMate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.reserve.logic.Messages;
 import seedu.reserve.model.Model;
 import seedu.reserve.model.ModelManager;
 import seedu.reserve.model.UserPrefs;
@@ -35,5 +37,14 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyList_throwsCommandException() {
+        // Create an empty model
+        Model emptyModel = new ModelManager();
+
+        // Check for CommandException
+        assertCommandFailure(new ListCommand(), emptyModel, Messages.MESSAGE_EMPTY_RESERVATION_LIST);
     }
 }


### PR DESCRIPTION
This PR fixes the bug in the ListCommand where an empty reservation list was showing the wrong output. It now correctly throws a CommandException with the message Messages.MESSAGE_EMPTY_RESERVATION_LIST. 

Additionally, the Developer Guide (DG) and User Guide (UG) have been updated to reflect this behaviour. 

Fix #93 #92 