### PR TITLE
Add phone constraints

### DIFF
--- a/src/main/java/seedu/reserve/model/reservation/Phone.java
+++ b/src/main/java/seedu/reserve/model/reservation/Phone.java
@@ -9,8 +9,8 @@ import static seedu.reserve.commons.util.AppUtil.checkArgument;
  */
 public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
-        "Phone numbers should only contain numbers," +
-                " it should begins with either 8 or 9 and it should be at least 8 digits long";
+        "Phone numbers should only contain numbers,"
+                + " it should begins with either 8 or 9 and it should be at least 8 digits long";
     public static final String VALIDATION_REGEX = "[89]\\d{7,}";
     public final String value;
 

--- a/src/main/java/seedu/reserve/model/reservation/Phone.java
+++ b/src/main/java/seedu/reserve/model/reservation/Phone.java
@@ -9,8 +9,9 @@ import static seedu.reserve.commons.util.AppUtil.checkArgument;
  */
 public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
-        "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+        "Phone numbers should only contain numbers," +
+                " it should begins with either 8 or 9 and it should be at least 8 digits long";
+    public static final String VALIDATION_REGEX = "[89]\\d{7,}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/reserve/model/reservation/Phone.java
+++ b/src/main/java/seedu/reserve/model/reservation/Phone.java
@@ -10,7 +10,7 @@ import static seedu.reserve.commons.util.AppUtil.checkArgument;
 public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
         "Phone numbers should only contain numbers,"
-                + " it should begins with either 8 or 9 and it should be at least 8 digits long";
+                + " it should begins with either 8 or 9 and it must be exactly 8 digits long";
     public static final String VALIDATION_REGEX = "[89]\\d{7}";
     public final String value;
 

--- a/src/main/java/seedu/reserve/model/reservation/Phone.java
+++ b/src/main/java/seedu/reserve/model/reservation/Phone.java
@@ -11,7 +11,7 @@ public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
         "Phone numbers should only contain numbers,"
                 + " it should begins with either 8 or 9 and it should be at least 8 digits long";
-    public static final String VALIDATION_REGEX = "[89]\\d{7,}";
+    public static final String VALIDATION_REGEX = "[89]\\d{7}";
     public final String value;
 
     /**

--- a/src/test/data/JsonSerializableReserveMateTest/typicalReservationReserveMate.json
+++ b/src/test/data/JsonSerializableReserveMateTest/typicalReservationReserveMate.json
@@ -56,22 +56,6 @@
       "diners": "10",
       "dateTime": "2040-06-18 1300",
       "tags": []
-    },
-    {
-      "name": "Hoon Meier",
-      "phone": "84824244",
-      "email": "stefan@example.com",
-      "diners": "6",
-      "dateTime": "2040-05-01 0900",
-      "tags": []
-    },
-    {
-      "name": "Ida Mueller",
-      "phone": "84821315",
-      "email": "hans@example.com",
-      "diners": "8",
-      "dateTime": "2040-04-15 1700",
-      "tags": []
     }
   ]
 }

--- a/src/test/data/JsonSerializableReserveMateTest/typicalReservationReserveMate.json
+++ b/src/test/data/JsonSerializableReserveMateTest/typicalReservationReserveMate.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "Elle Meyer",
-      "phone": "9482224",
+      "phone": "94822241",
       "email": "werner@example.com",
       "diners": "1",
       "dateTime": "2040-08-05 1000",
@@ -43,7 +43,7 @@
     },
     {
       "name": "Fiona Kunz",
-      "phone": "9482427",
+      "phone": "94824272",
       "email": "lydia@example.com",
       "diners": "7",
       "dateTime": "2040-07-12 1100",
@@ -51,10 +51,26 @@
     },
     {
       "name": "George Best",
-      "phone": "9482442",
+      "phone": "94824423",
       "email": "anna@example.com",
       "diners": "10",
       "dateTime": "2040-06-18 1300",
+      "tags": []
+    },
+    {
+      "name": "Hoon Meier",
+      "phone": "84824244",
+      "email": "stefan@example.com",
+      "diners": "6",
+      "dateTime": "2040-05-01 0900",
+      "tags": []
+    },
+    {
+      "name": "Ida Mueller",
+      "phone": "84821315",
+      "email": "hans@example.com",
+      "diners": "8",
+      "dateTime": "2040-04-15 1700",
       "tags": []
     }
   ]

--- a/src/test/java/seedu/reserve/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/reserve/logic/commands/CommandTestUtil.java
@@ -29,8 +29,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "99999999";
+    public static final String VALID_PHONE_BOB = "88888888";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_DINERS_AMY = "2";

--- a/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
@@ -30,7 +30,7 @@ public class ParserUtilTest {
     private static final String INVALID_DATETIME = "2026-12-12 180";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "98765432";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_DINERS = "2";
     private static final String VALID_DATETIME = "2030-12-12 1800";

--- a/src/test/java/seedu/reserve/model/reservation/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/NameContainsKeywordsPredicateTest.java
@@ -70,7 +70,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match phone and email but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new ReservationBuilder().withName("Alice").withPhone("12345")
+        assertFalse(predicate.test(new ReservationBuilder().withName("Alice").withPhone("98765432")
                 .withEmail("alice@email.com").build()));
     }
 

--- a/src/test/java/seedu/reserve/model/reservation/PhoneTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/PhoneTest.java
@@ -40,10 +40,10 @@ public class PhoneTest {
 
     @Test
     public void equals() {
-        Phone phone = new Phone("999");
+        Phone phone = new Phone("87654321");
 
         // same values -> returns true
-        assertTrue(phone.equals(new Phone("999")));
+        assertTrue(phone.equals(new Phone("87654321")));
 
         // same object -> returns true
         assertTrue(phone.equals(phone));
@@ -55,6 +55,6 @@ public class PhoneTest {
         assertFalse(phone.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(phone.equals(new Phone("995")));
+        assertFalse(phone.equals(new Phone("98765432")));
     }
 }

--- a/src/test/java/seedu/reserve/model/reservation/PhoneTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/PhoneTest.java
@@ -27,15 +27,14 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
+        assertFalse(Phone.isValidPhone("9112234")); // less than 8 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
+        assertTrue(Phone.isValidPhone("91128765")); // exactly 8 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
     }
 
     @Test

--- a/src/test/java/seedu/reserve/testutil/TypicalReservation.java
+++ b/src/test/java/seedu/reserve/testutil/TypicalReservation.java
@@ -55,21 +55,21 @@ public class TypicalReservation {
             .build();
 
     public static final Reservation ELLE = new ReservationBuilder().withName("Elle Meyer")
-            .withPhone("9482224")
+            .withPhone("94822241")
             .withEmail("werner@example.com")
             .withDiners("1")
             .withDateTime("2040-08-05 1000")
             .build();
 
     public static final Reservation FIONA = new ReservationBuilder().withName("Fiona Kunz")
-            .withPhone("9482427")
+            .withPhone("94824272")
             .withEmail("lydia@example.com")
             .withDiners("7")
             .withDateTime("2040-07-12 1100")
             .build();
 
     public static final Reservation GEORGE = new ReservationBuilder().withName("George Best")
-            .withPhone("9482442")
+            .withPhone("94824423")
             .withEmail("anna@example.com")
             .withDiners("10")
             .withDateTime("2040-06-18 1300")
@@ -77,14 +77,14 @@ public class TypicalReservation {
 
     // Manually added
     public static final Reservation HOON = new ReservationBuilder().withName("Hoon Meier")
-            .withPhone("8482424")
+            .withPhone("84824244")
             .withEmail("stefan@example.com")
             .withDiners("6")
             .withDateTime("2040-05-01 0900")
             .build();
 
     public static final Reservation IDA = new ReservationBuilder().withName("Ida Mueller")
-            .withPhone("8482131")
+            .withPhone("84821315")
             .withEmail("hans@example.com")
             .withDiners("8")
             .withDateTime("2040-04-15 1700")

--- a/src/test/java/seedu/reserve/testutil/TypicalReservation.java
+++ b/src/test/java/seedu/reserve/testutil/TypicalReservation.java
@@ -75,7 +75,6 @@ public class TypicalReservation {
             .withDateTime("2040-06-18 1300")
             .build();
 
-    // Manually added
     public static final Reservation HOON = new ReservationBuilder().withName("Hoon Meier")
             .withPhone("84824244")
             .withEmail("stefan@example.com")


### PR DESCRIPTION
- Require `phone` to contains only 8 characters.
- Require 'phone' to start with either 8 or 9

Fixes #83 