### PR TITLE
Update PaserClasses.puml to include ReserveMate

### DIFF
--- a/docs/diagrams/ParserClasses.puml
+++ b/docs/diagrams/ParserClasses.puml
@@ -9,7 +9,7 @@ Class XYZCommand
 
 package "Parser classes"{
 Class "<<interface>>\nParser" as Parser
-Class AddressBookParser
+Class ReservateMateParser
 Class XYZCommandParser
 Class CliSyntax
 Class ParserUtil
@@ -19,12 +19,12 @@ Class Prefix
 }
 
 Class HiddenOutside #FFFFFF
-HiddenOutside ..> AddressBookParser
+HiddenOutside ..> ReservateMateParser
 
-AddressBookParser .down.> XYZCommandParser: <<create>>
+ReservateMateParser .down.> XYZCommandParser: <<create>>
 
 XYZCommandParser ..> XYZCommand : <<create>>
-AddressBookParser ..> Command : <<use>>
+ReservateMateParser ..> Command : <<use>>
 XYZCommandParser .up.|> Parser
 XYZCommandParser ..> ArgumentMultimap
 XYZCommandParser ..> ArgumentTokenizer


### PR DESCRIPTION
Remodel paserclasses.puml to include ReservateMate instead of addressbook

![image](https://github.com/user-attachments/assets/d4cb0f9c-8820-49a2-b53c-a368cf14cd90)



fix #140