### PR TITLE
Add filter command

### DIFF
--- a/src/main/java/seedu/reserve/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/FilterCommand.java
@@ -1,0 +1,67 @@
+package seedu.reserve.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_END_DATE;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_START_DATE;
+
+import seedu.reserve.commons.util.ToStringBuilder;
+import seedu.reserve.logic.commands.exceptions.CommandException;
+import seedu.reserve.model.Model;
+import seedu.reserve.model.reservation.DateTime;
+import seedu.reserve.model.reservation.ReservationBetweenDatePredicate;
+
+/**
+ * Filters all reservations which are between a {@code startDate} and {@code endDate} provided by the user.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all reservations made between the given"
+            + " date range. \n"
+            + "Parameters: "
+            + PREFIX_START_DATE + "START DATE "
+            + PREFIX_END_DATE + "END DATE \n"
+            + "Example: " + COMMAND_WORD + " sd/" + " 2026-12-31 1800 " + "ed/" + " 2026-12-31 1900";
+
+    public static final String MESSAGE_SUCCESS = "Here are the available reservations for the date range.";
+    public static final String MESSAGE_NO_RESERVATIONS = "No reservations found for the date range.";
+
+    private final ReservationBetweenDatePredicate predicate;
+
+    public FilterCommand(DateTime startDate, DateTime endDate) {
+        this.predicate = new ReservationBetweenDatePredicate(startDate, endDate);
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.updateFilteredReservationList(predicate);
+        if (model.getFilteredReservationList().isEmpty()) {
+            return new CommandResult(MESSAGE_NO_RESERVATIONS);
+        }
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        FilterCommand otherFilterCommand = (FilterCommand) other;
+        return this.predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/reserve/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/AddCommandParser.java
@@ -7,9 +7,9 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.reserve.logic.commands.AddCommand;
 import seedu.reserve.logic.parser.exceptions.ParseException;
@@ -56,12 +56,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         return new AddCommand(reservation);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
+
 
 }

--- a/src/main/java/seedu/reserve/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/reserve/logic/parser/CliSyntax.java
@@ -12,4 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DATE_TIME = new Prefix("d/");
     public static final Prefix PREFIX_NUMBER_OF_DINERS = new Prefix("x/");
+    public static final Prefix PREFIX_START_DATE = new Prefix("sd/");
+    public static final Prefix PREFIX_END_DATE = new Prefix("ed/");
 }

--- a/src/main/java/seedu/reserve/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/FilterCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.reserve.logic.parser;
+
+import static seedu.reserve.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_END_DATE;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_START_DATE;
+import static seedu.reserve.logic.parser.ParserUtil.arePrefixesPresent;
+
+import seedu.reserve.logic.commands.FilterCommand;
+import seedu.reserve.logic.parser.exceptions.ParseException;
+import seedu.reserve.model.reservation.DateTime;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    public static final String MESSAGE_INVALID_ORDER = "Start date must be before end date";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public FilterCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_START_DATE, PREFIX_END_DATE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_START_DATE, PREFIX_END_DATE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        DateTime startDate = ParserUtil.parseDateTimeFilter(argMultimap.getValue(PREFIX_START_DATE).get());
+        DateTime endDate = ParserUtil.parseDateTimeFilter(argMultimap.getValue(PREFIX_END_DATE).get());
+        // Checks if the start date is after the end date
+        if (startDate.compareTo(endDate) > 0) {
+            throw new ParseException(MESSAGE_INVALID_ORDER);
+        }
+
+        return new FilterCommand(startDate, endDate);
+
+    }
+
+
+
+
+}

--- a/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
@@ -2,9 +2,11 @@ package seedu.reserve.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.DateTimeException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.reserve.commons.core.index.Index;
 import seedu.reserve.commons.util.StringUtil;
@@ -141,6 +143,41 @@ public class ParserUtil {
             throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
         }
         return new DateTime(trimmedDateTime);
+    }
+
+    /**
+     * Parses a {@code dateTimeFile} to a {@code  DateTime}. Does not check if {@code dateTimeFile}
+     * is after today's date.
+     *
+     * @param dateTimeFile
+     * @return DateTime object of {@code dateTimeFile}
+     * @throws ParseException if the given {@code dateTimeFile} is invalid
+     */
+    public static DateTime parseDateTimeFilter(String dateTimeFile) throws ParseException {
+        requireNonNull(dateTimeFile);
+        String trimmedDateTime = dateTimeFile.trim();
+
+        if (!DateTime.isValidFileInputDateTime(trimmedDateTime)) {
+            throw new ParseException(DateTime.MESSAGE_CONSTRAINTS_FILTER);
+        }
+
+        DateTime dateTime;
+
+        try {
+            dateTime = DateTime.fromFileString(trimmedDateTime);
+        } catch (DateTimeException e) {
+            throw new ParseException(DateTime.MESSAGE_CONSTRAINTS_FILTER);
+        }
+
+        return dateTime;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/reserve/logic/parser/ReserveMateParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/ReserveMateParser.java
@@ -14,6 +14,7 @@ import seedu.reserve.logic.commands.Command;
 import seedu.reserve.logic.commands.DeleteCommand;
 import seedu.reserve.logic.commands.EditCommand;
 import seedu.reserve.logic.commands.ExitCommand;
+import seedu.reserve.logic.commands.FilterCommand;
 import seedu.reserve.logic.commands.FindCommand;
 import seedu.reserve.logic.commands.HelpCommand;
 import seedu.reserve.logic.commands.ListCommand;
@@ -80,6 +81,9 @@ public class ReserveMateParser {
 
         case ShowCommand.COMMAND_WORD:
             return new ShowCommandParser().parse(arguments);
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/reserve/model/reservation/DateTime.java
+++ b/src/main/java/seedu/reserve/model/reservation/DateTime.java
@@ -17,6 +17,7 @@ public class DateTime implements Comparable<DateTime> {
 
     public static final String MESSAGE_CONSTRAINTS = "DateTime must be in the format YYYY-MM-DD HHmm "
             + "and be a date-time after the current time.";
+    public static final String MESSAGE_CONSTRAINTS_FILTER = "DateTime must be in the format YYYY-MM-DD HHmm";
     public static final String VALIDATION_REGEX = "^\\d{4}-\\d{2}-\\d{2} \\d{4}$";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
 
@@ -105,5 +106,17 @@ public class DateTime implements Comparable<DateTime> {
     @Override
     public int compareTo(DateTime dateTime) {
         return this.value.compareTo(dateTime.value);
+    }
+
+    /**
+     * Returns True if the current {@code DateTime} object's date and time is between the start and end
+     * {@code DateTime} objects (inclusive). The {@code startDateTime} must be before {@end endDateTime}.
+     *
+     * @param startDateTime start date
+     * @param endDateTime end date
+     * @return true if conditions met, false otherwise
+     */
+    public boolean isBetween(DateTime startDateTime, DateTime endDateTime) {
+        return this.compareTo(startDateTime) >= 0 && this.compareTo(endDateTime) <= 0;
     }
 }

--- a/src/main/java/seedu/reserve/model/reservation/ReservationBetweenDatePredicate.java
+++ b/src/main/java/seedu/reserve/model/reservation/ReservationBetweenDatePredicate.java
@@ -1,0 +1,49 @@
+package seedu.reserve.model.reservation;
+
+import java.util.function.Predicate;
+
+import seedu.reserve.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Reservation}'s {@code DateTime} is between a given start and end {@code DateTime}
+ */
+public class ReservationBetweenDatePredicate implements Predicate<Reservation> {
+    private final DateTime startDate;
+    private final DateTime endDate;
+
+    /**
+     * Constructor to create predicate given the start and end date
+     */
+    public ReservationBetweenDatePredicate(DateTime startDate, DateTime endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    @Override
+    public boolean test(Reservation reservation) {
+        DateTime reservationDateTime = reservation.getDateTime();
+        return reservationDateTime.isBetween(startDate, endDate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ReservationBetweenDatePredicate)) {
+            return false;
+        }
+
+        ReservationBetweenDatePredicate compare = (ReservationBetweenDatePredicate) other;
+        if ((this.startDate.equals(compare.startDate)) && (this.endDate.equals(compare.endDate))) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("startDate", this.startDate)
+                .add("endDate", this.endDate).toString();
+    }
+}

--- a/src/test/java/seedu/reserve/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/FilterCommandTest.java
@@ -1,0 +1,77 @@
+package seedu.reserve.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.reserve.testutil.TypicalReservation.getTypicalReserveMate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.reserve.model.Model;
+import seedu.reserve.model.ModelManager;
+import seedu.reserve.model.UserPrefs;
+import seedu.reserve.model.reservation.DateTime;
+import seedu.reserve.model.reservation.ReservationBetweenDatePredicate;
+
+public class FilterCommandTest {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
+    private static DateTime endDate = DateTime.fromFileString(LocalDateTime.now().plusDays(1)
+            .format(FORMATTER).toString());
+    private static DateTime startDate = DateTime.fromFileString(LocalDateTime.now().format(FORMATTER).toString());
+    private static DateTime startDate2 = DateTime.fromFileString(LocalDateTime.now()
+            .plusHours(1).format(FORMATTER).toString());
+
+    private Model model = new ModelManager(getTypicalReserveMate(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalReserveMate(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        FilterCommand filterCommand = new FilterCommand(startDate, endDate);
+        FilterCommand filterCommand2 = new FilterCommand(startDate, endDate);
+        FilterCommand filterCommand3 = new FilterCommand(startDate2, endDate);
+
+        // check same object
+        assertTrue(filterCommand.equals(filterCommand));
+
+        // check same start and end dates
+        assertTrue(filterCommand.equals(filterCommand2));
+
+        // check different start and end dates
+        assertFalse(filterCommand.equals(filterCommand3));
+
+        // different types -> returns false
+        assertFalse(filterCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterCommand.equals(null));
+    }
+
+    @Test
+    public void filterCommand_noReservationsFound() {
+        DateTime startDate = DateTime.fromFileString("2015-05-13 1400");
+        DateTime endDate = DateTime.fromFileString("2015-05-13 1500");
+        // target result
+        ReservationBetweenDatePredicate predicate = new ReservationBetweenDatePredicate(startDate, endDate);
+        expectedModel.updateFilteredReservationList(predicate);
+        String expectedMessage = FilterCommand.MESSAGE_NO_RESERVATIONS;
+        // model
+        FilterCommand filterCommand = new FilterCommand(startDate, endDate);
+
+        assertCommandSuccess(filterCommand, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredReservationList());
+    }
+
+
+    @Test
+    public void toStringTest() {
+        ReservationBetweenDatePredicate predicate = new ReservationBetweenDatePredicate(startDate, endDate);
+        FilterCommand filterCommand = new FilterCommand(startDate, endDate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+}

--- a/src/test/java/seedu/reserve/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,49 @@
+package seedu.reserve.logic.parser;
+
+import static seedu.reserve.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.reserve.logic.commands.FilterCommand;
+import seedu.reserve.model.reservation.DateTime;
+
+public class FilterCommandParserTest {
+
+    private final FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void filterParse_noArguments() throws Exception {
+        assertParseFailure(parser, "  ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void filterParse_invalidNumberOfArguments() throws Exception {
+        assertParseFailure(parser, " sd/ 2026-12-01 1300", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " ed/ 2026-12-01 1400", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void filterParse_invalidCliSyntax() throws Exception {
+        assertParseFailure(parser, " sdm/ 2026-12-01 1300 eds/ 2026-12-04 1600",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+
+    }
+
+    @Test
+    public void filterParse_startDateBeforeEndDate() throws Exception {
+        assertParseFailure(parser, " sd/ 2026-12-15 1500 ed/ 2025-12-12 1400",
+                FilterCommandParser.MESSAGE_INVALID_ORDER);
+    }
+
+    @Test
+    public void filterParse_success() throws Exception {
+        DateTime startDate = DateTime.fromFileString("2026-12-01 1300");
+        DateTime endDate = DateTime.fromFileString("2026-12-01 1400");
+        FilterCommand expectedFilter = new FilterCommand(startDate, endDate);
+        assertParseSuccess(parser, " sd/ 2026-12-01 1300 ed/ 2026-12-01 1400", expectedFilter);
+    }
+}

--- a/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
@@ -28,12 +28,14 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_DINERS = "0";
     private static final String INVALID_DATETIME = "2026-12-12 180";
+    private static final String INVALID_FILTER_DATETIME = "2025-13-01 1900";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "98765432";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_DINERS = "2";
     private static final String VALID_DATETIME = "2030-12-12 1800";
+    private static final String VALID_FILTER_DATETIME = "2025-01-01 1400";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
@@ -172,6 +174,32 @@ public class ParserUtilTest {
         String dateTimeWithWhitespace = WHITESPACE + VALID_DATETIME + WHITESPACE;
         DateTime expectedDateTime = new DateTime(VALID_DATETIME);
         assertEquals(expectedDateTime, ParserUtil.parseDateTime(dateTimeWithWhitespace));
+    }
+
+    @Test
+    public void parseDateTimeFilter_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDateTimeFilter(null));
+    }
+
+    @Test
+    public void parseDateTimeFilter_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDateTimeFilter(INVALID_FILTER_DATETIME));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDateTimeFilter(INVALID_DATETIME));
+    }
+
+    @Test
+    public void parseDateTimeFilter_validValue_returnsDateTime() throws Exception {
+        DateTime expectedDateTime = DateTime.fromFileString(VALID_FILTER_DATETIME);
+        assertEquals(expectedDateTime, ParserUtil.parseDateTimeFilter(VALID_FILTER_DATETIME));
+        DateTime expectedDateTimeAfter = new DateTime(VALID_DATETIME);
+        assertEquals(expectedDateTimeAfter, ParserUtil.parseDateTimeFilter(VALID_DATETIME));
+    }
+
+    @Test
+    public void parseDateTimeFilter_validValueWithWhitespace_returnsTrimmedDateTime() throws Exception {
+        String dateTimeWithWhitespace = WHITESPACE + VALID_FILTER_DATETIME + WHITESPACE;
+        DateTime expectedDateTime = ParserUtil.parseDateTimeFilter(dateTimeWithWhitespace);
+        assertEquals(expectedDateTime, ParserUtil.parseDateTimeFilter(dateTimeWithWhitespace));
     }
 
     @Test

--- a/src/test/java/seedu/reserve/logic/parser/ReserveMateParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ReserveMateParserTest.java
@@ -18,10 +18,12 @@ import seedu.reserve.logic.commands.ClearCommand;
 import seedu.reserve.logic.commands.DeleteCommand;
 import seedu.reserve.logic.commands.EditCommand;
 import seedu.reserve.logic.commands.ExitCommand;
+import seedu.reserve.logic.commands.FilterCommand;
 import seedu.reserve.logic.commands.FindCommand;
 import seedu.reserve.logic.commands.HelpCommand;
 import seedu.reserve.logic.commands.ListCommand;
 import seedu.reserve.logic.parser.exceptions.ParseException;
+import seedu.reserve.model.reservation.DateTime;
 import seedu.reserve.model.reservation.NameContainsKeywordsPredicate;
 import seedu.reserve.model.reservation.Reservation;
 import seedu.reserve.testutil.EditReservationDescriptorBuilder;
@@ -144,6 +146,23 @@ public class ReserveMateParserTest {
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
             HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
+    }
+
+    @Test
+    public void parseCommand_filter_success() throws Exception {
+        DateTime startTime = DateTime.fromFileString("2025-12-13 1800");
+        DateTime endTime = DateTime.fromFileString("2025-12-13 1900");
+        FilterCommand command = (FilterCommand) parser.parseCommand("filter sd/ 2025-12-13 1800 ed/ 2025-12-13 1900");
+
+        assertEquals(new FilterCommand(startTime, endTime), command);
+    }
+
+    @Test
+    public void parseCommand_filter_failure() throws Exception {
+        assertThrows(ParseException.class, () -> parser.parseCommand("filter "));
+        assertThrows(ParseException.class, () -> parser.parseCommand("filter sd/ ed/ "));
+        assertThrows(ParseException.class, () -> parser.parseCommand("filter sd/ 2025-12-13 1800 ed/"));
+        assertThrows(ParseException.class, () -> parser.parseCommand("filter ed/ 2025-12-13 1900 "));
     }
 
     @Test

--- a/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
@@ -11,15 +11,19 @@ import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+
 public class DateTimeTest {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
     private static final String INVALID_DATE_TIME_FORMAT_STR = "2025-12-12 180";
+    private static final DateTime endDate = DateTime.fromFileString("2025-12-15 1800");
+    private static final DateTime middleDate = DateTime.fromFileString("2025-12-13 1400");
+    private static final DateTime outOfBoundsDate = DateTime.fromFileString("2025-12-16 1800");
+    private static final DateTime startDate = DateTime.fromFileString("2025-12-12 1800");
 
     private String formattedYesterdayDateTime;
     private String formattedTomorrowDateTime;
     private String formattedDayAfterDateTime;
-
 
     /**
      * Helper method to generate a formatted date string based on the current date and time.
@@ -109,4 +113,18 @@ public class DateTimeTest {
         // different date and time value -> return false
         assertFalse(dateTime.equals(new DateTime(formattedDayAfterDateTime)));
     }
+
+    @Test
+    public void isBetween() {
+        // date in between both start and end date
+        assertTrue(middleDate.isBetween(startDate, endDate));
+
+        // date out of bounds
+        assertFalse(outOfBoundsDate.isBetween(startDate, endDate));
+
+        // edge dates
+        assertTrue(startDate.isBetween(startDate, endDate));
+        assertTrue(endDate.isBetween(startDate, endDate));
+    }
+
 }


### PR DESCRIPTION
Implement a filter command that allows users to filter reservations between two dates

To implement filter command,
* Add relevant syntax in the CliSyntax file
* Implement FilterCommand and FilterCommandParser
* Implement ReservationBetweenDatePredicate for filtering reservations
* Move arePrefixesPresent method to ParserUtil to reduce code
duplication
* Add isBetween method in DateTime for filtering


Fix #128 

