### PR TITLE
Implement reservations by occasion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,23 @@ ReserveMate supports a variety of commands to help you manage your reservations:
 ### Feature: Create a new reservation
 **Purpose:** The create function will enable users to add new reservations to reserve by capturing relevant details such as name, number of diners, contact information, date and time of reservation.
 
-**Command format:** `add n/<NAME> p/<PHONE> e/<EMAIL> x/<NUMBER_OF_DINERS> d/<DATETIME> [t/TAG]...…​`
+**Command format:** `add n/<NAME> p/<PHONE> e/<EMAIL> x/<NUMBER_OF_DINERS> d/<DATETIME> <o/OCCASION>...…​`
 
 **Example commands:**
 ```
-add n/John Doe p/98765432 e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy
-ADD n/John Doe e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy p/98765432
+add n/John Doe p/98765432 e/johnd@example.com x/5 d/2026-12-12 1800 o/Birthday
+ADD n/John Doe e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy o/Anniversary
 ```
 
 ### Feature: Editing a reservation
 **Purpose:** The edit function will enable users to edit existing reservations by specifying the detail(s) of the reservation to be changed.
 
-**Command format:** `edit <INDEX> [n/NAME] [p/PHONE] [e/EMAIL] [x/NUMBER_OF_DINERS] [d/DATETIME] [t/TAG]…​`
+**Command format:** `edit <INDEX> [n/NAME] [p/PHONE] [e/EMAIL] [x/NUMBER_OF_DINERS] [d/DATETIME] [o/OCCASION]…​`
 
 **Example commands:**
 ```
-edit 1 n/John Doe p/98765432 e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy
-EDIT 1 n/John Doe e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy p/98765432
+edit 1 n/John Doe p/98765432 e/johnd@example.com x/5 d/2026-12-12 1800 o/Birthday
+EDIT 1 n/John Doe e/johnd@example.com x/5 d/2026-12-12 1800 o/Anniversary p/98765432
 edit 1 d/2026-12-12 1800
 ```
 ### Feature: Delete reservation by reservation number

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -29,7 +29,7 @@ ReserveMate is a **desktop app for managing reservations, optimized for use via 
 1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will list all available commands.<br>
    Some example commands you can try:
 
-   * `add n/John Doe p/98765432 e/johnd@example.com x/5 d/2026-12-12 1800 t/Nut allergy` : Adds a reservation named `John Doe` to the ReserveMate.
+   * `add n/John Doe p/98765432 e/johnd@example.com x/5 d/2026-12-12 1800 o/Birthday` : Adds a reservation named `John Doe` to the ReserveMate.
 
    * `edit 2 n/Bobby p/98765432 e/bobby@example.com` : Updates the 2nd reservation shown in the reservation list to reflect new details of at least one specified tag.
 
@@ -61,13 +61,13 @@ ReserveMate is a **desktop app for managing reservations, optimized for use via 
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
 * Words in `[UPPER_CASE]` are optional parameters to be supplied by the user.<br>
-  e.g. in `add t/[TAG]`, `TAG` is a parameter which can be used as `add t/Vegan`.
+  e.g. in `edit <INDEX> p/96214711`, `PHONE_NUMBER` is a parameter which can be used as `add n/John Doe p/96214711`.
 
 * Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+  e.g `edit <INDEX> [o/OCCASION]` can be used as `n/John Doe o/Birthday` or as `n/John Doe`.
 
 * Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/nutAllergy`, `t/friend t/family` etc.
+  e.g. `[o/OCCASION]…​` can be used as ` ` (i.e. 0 times), `o/Birthday`, `o/Birthday o/Graduation` etc.
 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
@@ -110,7 +110,7 @@ Examples:
 
 Adds a reservation to the ReserveMate.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL x/NUMBER_OF_DINER d/DATE_TIME [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL x/NUMBER_OF_DINER d/DATE_TIME [o/OCCASION]…​`
 
 <box type="constraint" seamless>
 
@@ -120,8 +120,8 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL x/NUMBER_OF_DINER d/DATE_TIME [t/TAG]
 </box>
 
 Examples:
-* `add n/John Doe p/6598765432 e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy`
-* `add n/Jane Doe t/friend e/betsycrowe@example.com x/5 p/6581234567 t/vegan d/2026-12-12 1800`
+* `add n/John Doe p/6598765432 e/johnd@example.com x/5 d/2026-12-12 1800 o/BIRTHDAY`
+* `add n/Jane Doe t/friend e/betsycrowe@example.com x/5 p/6581234567 o/GRADUATION d/2026-12-12 1800`
 
 ### Listing all reservations : `list`
 
@@ -136,7 +136,7 @@ Examples:
 
 Edits an existing reservation in ReserveMate.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [d/DATE_TIME] [x/NUMBER_OF_DINERS] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [d/DATE_TIME] [x/NUMBER_OF_DINERS] [o/OCCASION]…​`
 
 * Edits the reservation at the specified `INDEX`. The index refers to the index number shown in the displayed reservation list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -148,7 +148,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [d/DATE_TIME] [x/NUMBER_OF_DINE
 ![editCommandResult.png](images/editCommandResult.png)
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st reservation to be `91234567` and `johndoe@example.com` respectively.
-*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd reservation to be `Betsy Crower` and clears all existing tags.
+*  `edit 2 n/Betsy Crower o/` Edits the name of the 2nd reservation to be `Betsy Crower` and clears all existing occasions.
 
 ### Locating reservations by name: `find`
 
@@ -234,10 +234,10 @@ _Details coming soon ..._
 
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL x/NUMBER_OF_DINER d/DATE_TIME [t/TAG]…​` <br> e.g., `add n/John Doe p/6598765432 e/johnd@example.com x/5 d/2026-12-12 1800 t/nutAllergy`
+**Add**    | `add <n/NAME> <p/PHONE_NUMBER> <e/EMAIL> <x/NUMBER_OF_DINER> <d/DATE_TIME> <o/OCCASION…​>` <br> e.g., `add n/John Doe p/6598765432 e/johnd@example.com x/5 d/2026-12-12 1800 o/Birthday`
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [x/NUMBER_OF_DINERS] [d/DATE_TIME] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [x/NUMBER_OF_DINERS] [d/DATE_TIME] [o/OCCASION]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **Show**   | `show INDEX`<br> e.g., `show 2`
 **List**   | `list`

--- a/src/main/java/seedu/reserve/logic/Messages.java
+++ b/src/main/java/seedu/reserve/logic/Messages.java
@@ -47,7 +47,7 @@ public class Messages {
                 .append(reservation.getEmail())
                 .append("; Number of Diners: ")
                 .append(reservation.getDiners().value)
-                .append("; Tags: ");
+                .append("; Occasion: ");
         reservation.getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/reserve/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/AddCommand.java
@@ -5,8 +5,8 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import seedu.reserve.commons.util.ToStringBuilder;
 import seedu.reserve.logic.Messages;
@@ -40,7 +40,9 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New reservation added: %1$s";
     public static final String MESSAGE_DUPLICATE_RESERVATION =
             "This reservation already exists in the reservation book";
-    public static final String MESSAGE_NO_OCCASION = "No occasion selected";
+    public static final String MESSAGE_NO_OCCASION = "Please indicate an occasion \n"
+        + "Example: " + PREFIX_OCCASION + "Birthday \n"
+        + "Example: " + PREFIX_OCCASION + "None";
 
     private final Reservation toAdd;
 
@@ -60,9 +62,9 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_RESERVATION);
         }
 
-//        if (toAdd.getTags().isEmpty()) {
-//            throw new CommandException(MESSAGE_NO_OCCASION);
-//        }
+        if (toAdd.getTags().isEmpty()) {
+            throw new CommandException(MESSAGE_NO_OCCASION);
+        }
 
         model.addReservation(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));

--- a/src/main/java/seedu/reserve/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/AddCommand.java
@@ -6,7 +6,7 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 
 import seedu.reserve.commons.util.ToStringBuilder;
 import seedu.reserve.logic.Messages;
@@ -28,19 +28,19 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_NUMBER_OF_DINERS + "NUMBER OF DINERS "
             + PREFIX_DATE_TIME + "DATETIME "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_OCCASION + "OCCASION]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_NUMBER_OF_DINERS + "5 "
             + PREFIX_DATE_TIME + "2026-12-31 1800 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_OCCASION + "Birthday ";
 
     public static final String MESSAGE_SUCCESS = "New reservation added: %1$s";
     public static final String MESSAGE_DUPLICATE_RESERVATION =
             "This reservation already exists in the reservation book";
+    public static final String MESSAGE_NO_OCCASION = "No occasion selected";
 
     private final Reservation toAdd;
 
@@ -59,6 +59,10 @@ public class AddCommand extends Command {
         if (model.hasReservation(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_RESERVATION);
         }
+
+//        if (toAdd.getTags().isEmpty()) {
+//            throw new CommandException(MESSAGE_NO_OCCASION);
+//        }
 
         model.addReservation(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -6,7 +6,7 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 import static seedu.reserve.model.Model.PREDICATE_SHOW_ALL_RESERVATIONS;
 
 import java.time.LocalDateTime;
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_NUMBER_OF_DINERS + "NUMBER OF DINERS] "
             + "[" + PREFIX_DATE_TIME + "DATETIME] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_OCCASION + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com "

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -5,8 +5,8 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.model.Model.PREDICATE_SHOW_ALL_RESERVATIONS;
 
 import java.time.LocalDateTime;

--- a/src/main/java/seedu/reserve/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/AddCommandParser.java
@@ -6,8 +6,10 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 
+import java.util.HashSet;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -22,9 +24,17 @@ import seedu.reserve.model.reservation.Reservation;
 import seedu.reserve.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new AddCommand object.
  */
 public class AddCommandParser implements Parser<AddCommand> {
+
+    public static final String MESSAGE_IS_OCCASION = "Are you celebrating an occasion?";
+    public static final String MESSAGE_OCCASION_OPTIONS = "Select an option: \n"
+        + "1. Birthday \n"
+        + "2. Anniversary \n"
+        + "3. Graduation \n"
+        + "4. Others \n"
+        + "5. None \n";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
@@ -33,23 +43,23 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_NUMBER_OF_DINERS, PREFIX_DATE_TIME, PREFIX_TAG);
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_NUMBER_OF_DINERS, PREFIX_DATE_TIME, PREFIX_OCCASION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_NUMBER_OF_DINERS, PREFIX_DATE_TIME)
-                || !argMultimap.getPreamble().isEmpty()) {
+            PREFIX_NUMBER_OF_DINERS, PREFIX_DATE_TIME)
+            || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_NUMBER_OF_DINERS, PREFIX_DATE_TIME);
+            PREFIX_NUMBER_OF_DINERS, PREFIX_DATE_TIME);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Diners diners = ParserUtil.parseDiners(argMultimap.getValue(PREFIX_NUMBER_OF_DINERS).get());
         DateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE_TIME).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_OCCASION));
 
         Reservation reservation = new Reservation(name, phone, email, diners, dateTime, tagList);
 
@@ -63,5 +73,4 @@ public class AddCommandParser implements Parser<AddCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/seedu/reserve/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/AddCommandParser.java
@@ -5,11 +5,9 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.util.HashSet;
-import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -27,14 +25,6 @@ import seedu.reserve.model.tag.Tag;
  * Parses input arguments and creates a new AddCommand object.
  */
 public class AddCommandParser implements Parser<AddCommand> {
-
-    public static final String MESSAGE_IS_OCCASION = "Are you celebrating an occasion?";
-    public static final String MESSAGE_OCCASION_OPTIONS = "Select an option: \n"
-        + "1. Birthday \n"
-        + "2. Anniversary \n"
-        + "3. Graduation \n"
-        + "4. Others \n"
-        + "5. None \n";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand

--- a/src/main/java/seedu/reserve/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/reserve/logic/parser/CliSyntax.java
@@ -9,7 +9,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_OCCASION = new Prefix("o/");
     public static final Prefix PREFIX_DATE_TIME = new Prefix("d/");
     public static final Prefix PREFIX_NUMBER_OF_DINERS = new Prefix("x/");
 }

--- a/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
@@ -7,7 +7,7 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +33,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_DATE_TIME,
-                        PREFIX_NUMBER_OF_DINERS, PREFIX_TAG);
+                        PREFIX_NUMBER_OF_DINERS, PREFIX_OCCASION);
 
         Index index;
 
@@ -66,7 +66,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editReservationDescriptor
                     .setDateTime(ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE_TIME).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editReservationDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_OCCASION)).ifPresent(editReservationDescriptor::setTags);
 
         if (!editReservationDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
@@ -6,8 +6,8 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/seedu/reserve/model/reservation/Reservation.java
+++ b/src/main/java/seedu/reserve/model/reservation/Reservation.java
@@ -123,7 +123,7 @@ public class Reservation {
                 .add("email", email)
                 .add("diners", diners)
                 .add("dateTime", dateTime)
-                .add("tags", tags)
+                .add("occasion", tags)
                 .toString();
     }
 

--- a/src/test/java/seedu/reserve/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/AddCommandIntegrationTest.java
@@ -28,7 +28,7 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_newReservation_success() {
-        Reservation validReservation = new ReservationBuilder().build();
+        Reservation validReservation = new ReservationBuilder().withTags("Anniversary").build();
 
         Model expectedModel = new ModelManager(model.getReserveMate(), new UserPrefs());
         expectedModel.addReservation(validReservation);

--- a/src/test/java/seedu/reserve/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/AddCommandTest.java
@@ -38,7 +38,7 @@ public class AddCommandTest {
     @Test
     public void execute_reservationAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingReservationAdded modelStub = new ModelStubAcceptingReservationAdded();
-        Reservation validReservation = new ReservationBuilder().build();
+        Reservation validReservation = new ReservationBuilder().withTags("Birthday").build();;
 
         CommandResult commandResult = new AddCommand(validReservation).execute(modelStub);
 
@@ -49,12 +49,23 @@ public class AddCommandTest {
 
     @Test
     public void execute_duplicateReservation_throwsCommandException() {
-        Reservation validReservation = new ReservationBuilder().build();
+        Reservation validReservation = new ReservationBuilder().withTags("Birthday").build();;
         AddCommand addCommand = new AddCommand(validReservation);
         ModelStub modelStub = new ModelStubWithReservation(validReservation);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_RESERVATION, ()
                 -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_missingOccasion_throwsCommandException() {
+        ModelStubAcceptingReservationAdded modelStub = new ModelStubAcceptingReservationAdded();
+        Reservation reservationWithoutOccasion = new ReservationBuilder().withTags().build(); // No occasion
+
+        AddCommand addCommand = new AddCommand(reservationWithoutOccasion);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_NO_OCCASION, ()
+            -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/reserve/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/reserve/logic/commands/CommandTestUtil.java
@@ -7,7 +7,7 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 import static seedu.reserve.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -50,8 +50,8 @@ public class CommandTestUtil {
     public static final String DINERS_DESC_BOB = " " + PREFIX_NUMBER_OF_DINERS + VALID_DINERS_BOB;
     public static final String DATETIME_DESC_AMY = " " + PREFIX_DATE_TIME + VALID_DATETIME_AMY;
     public static final String DATETIME_DESC_BOB = " " + PREFIX_DATE_TIME + VALID_DATETIME_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_FRIEND = " " + PREFIX_OCCASION + VALID_TAG_FRIEND;
+    public static final String TAG_DESC_HUSBAND = " " + PREFIX_OCCASION + VALID_TAG_HUSBAND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -59,7 +59,7 @@ public class CommandTestUtil {
     public static final String INVALID_DINERS_DESC = " " + PREFIX_NUMBER_OF_DINERS + "0"; // '0' not in range
     public static final String INVALID_DATETIME_DESC = " "
             + PREFIX_DATE_TIME + "2026-12-12 180"; // not a valid date time
-    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TAG_DESC = " " + PREFIX_OCCASION + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/reserve/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/reserve/logic/commands/CommandTestUtil.java
@@ -6,8 +6,8 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -37,8 +37,8 @@ public class CommandTestUtil {
     public static final String VALID_DINERS_BOB = "4";
     public static final String VALID_DATETIME_AMY = "2026-12-12 1800";
     public static final String VALID_DATETIME_BOB = "2026-12-25 1200";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_OCCASION_BIRTHDAY = "Birthday";
+    public static final String VALID_OCCASION_ANNIVERSARY = "Anniversary";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -50,8 +50,8 @@ public class CommandTestUtil {
     public static final String DINERS_DESC_BOB = " " + PREFIX_NUMBER_OF_DINERS + VALID_DINERS_BOB;
     public static final String DATETIME_DESC_AMY = " " + PREFIX_DATE_TIME + VALID_DATETIME_AMY;
     public static final String DATETIME_DESC_BOB = " " + PREFIX_DATE_TIME + VALID_DATETIME_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_OCCASION + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_OCCASION + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_ANNIVERSARY = " " + PREFIX_OCCASION + VALID_OCCASION_ANNIVERSARY;
+    public static final String TAG_DESC_BIRTHDAY = " " + PREFIX_OCCASION + VALID_OCCASION_BIRTHDAY;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -59,7 +59,7 @@ public class CommandTestUtil {
     public static final String INVALID_DINERS_DESC = " " + PREFIX_NUMBER_OF_DINERS + "0"; // '0' not in range
     public static final String INVALID_DATETIME_DESC = " "
             + PREFIX_DATE_TIME + "2026-12-12 180"; // not a valid date time
-    public static final String INVALID_TAG_DESC = " " + PREFIX_OCCASION + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TAG_DESC = " " + PREFIX_OCCASION + "graduation*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -71,11 +71,11 @@ public class CommandTestUtil {
         DESC_AMY = new EditReservationDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
                 .withDiners(VALID_DINERS_AMY).withDateTime(VALID_DATETIME_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withTags(VALID_OCCASION_ANNIVERSARY).build();
         DESC_BOB = new EditReservationDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withDiners(VALID_DINERS_BOB).withDateTime(VALID_DATETIME_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY, VALID_OCCASION_ANNIVERSARY).build();
     }
 
     /**

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -8,8 +8,8 @@ import static seedu.reserve.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_DATETIME_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_DINERS_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.reserve.logic.commands.CommandTestUtil.showReservationAtIndex;
@@ -65,11 +65,11 @@ public class EditCommandTest {
         ReservationBuilder reservationInList = new ReservationBuilder(lastReservation);
         Reservation editedReservation = reservationInList.withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withDiners(VALID_DINERS_BOB).withDateTime(VALID_DATETIME_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY).build();
 
         EditCommand.EditReservationDescriptor descriptor = new EditReservationDescriptorBuilder()
                 .withName(VALID_NAME_BOB).withDiners(VALID_DINERS_BOB).withDateTime(VALID_DATETIME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withPhone(VALID_PHONE_BOB).withTags(VALID_OCCASION_BIRTHDAY).build();
         EditCommand editCommand = new EditCommand(indexLastReservation, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_RESERVATION_SUCCESS,

--- a/src/test/java/seedu/reserve/logic/commands/EditReservationDescriptorTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditReservationDescriptorTest.java
@@ -7,8 +7,8 @@ import static seedu.reserve.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +49,7 @@ public class EditReservationDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditReservationDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditReservationDescriptorBuilder(DESC_AMY).withTags(VALID_OCCASION_BIRTHDAY).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/reserve/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/AddCommandParserTest.java
@@ -17,13 +17,13 @@ import static seedu.reserve.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.reserve.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_ANNIVERSARY;
+import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_ANNIVERSARY;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
@@ -50,27 +50,27 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Reservation expectedReservation = new ReservationBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Reservation expectedReservation = new ReservationBuilder(BOB).withTags(VALID_OCCASION_BIRTHDAY).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + DINERS_DESC_BOB + DATETIME_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedReservation));
+                + TAG_DESC_BIRTHDAY, new AddCommand(expectedReservation));
 
 
         // multiple tags - all accepted
         Reservation expectedReservationMultipleTags = new ReservationBuilder(BOB)
-                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_ANNIVERSARY, VALID_OCCASION_BIRTHDAY).build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_ANNIVERSARY + TAG_DESC_BIRTHDAY,
                 new AddCommand(expectedReservationMultipleTags));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedReservationString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_FRIEND;
+                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_ANNIVERSARY;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedReservationString,
@@ -154,20 +154,24 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_BIRTHDAY
+                + TAG_DESC_ANNIVERSARY, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB
-                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_BIRTHDAY
+                + TAG_DESC_ANNIVERSARY, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC
-                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_BIRTHDAY
+                + TAG_DESC_ANNIVERSARY, Email.MESSAGE_CONSTRAINTS);
 
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + DINERS_DESC_BOB + DATETIME_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + DINERS_DESC_BOB + DATETIME_DESC_BOB + INVALID_TAG_DESC
+                + VALID_OCCASION_ANNIVERSARY, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
@@ -175,7 +179,7 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + DINERS_DESC_BOB + DATETIME_DESC_BOB + TAG_DESC_BIRTHDAY + TAG_DESC_ANNIVERSARY,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/reserve/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/EditCommandParserTest.java
@@ -20,7 +20,7 @@ import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.reserve.testutil.TypicalIndexes.INDEX_FIRST_RESERVATION;
@@ -41,7 +41,7 @@ import seedu.reserve.testutil.EditReservationDescriptorBuilder;
 
 public class EditCommandParserTest {
 
-    private static final String TAG_EMPTY = " " + PREFIX_TAG;
+    private static final String TAG_EMPTY = " " + PREFIX_OCCASION;
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);

--- a/src/test/java/seedu/reserve/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/EditCommandParserTest.java
@@ -10,17 +10,17 @@ import static seedu.reserve.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.reserve.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_ANNIVERSARY;
+import static seedu.reserve.logic.commands.CommandTestUtil.TAG_DESC_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_ANNIVERSARY;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.reserve.testutil.TypicalIndexes.INDEX_FIRST_RESERVATION;
@@ -87,9 +87,9 @@ public class EditCommandParserTest {
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Reservation} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_ANNIVERSARY + TAG_DESC_BIRTHDAY + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_ANNIVERSARY + TAG_EMPTY + TAG_DESC_BIRTHDAY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_ANNIVERSARY + TAG_DESC_BIRTHDAY, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
@@ -99,12 +99,12 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_RESERVATION;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_BIRTHDAY
+                + EMAIL_DESC_AMY + NAME_DESC_AMY + TAG_DESC_ANNIVERSARY;
 
         EditCommand.EditReservationDescriptor descriptor = new EditReservationDescriptorBuilder()
                 .withName(VALID_NAME_AMY).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY, VALID_OCCASION_ANNIVERSARY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -146,8 +146,8 @@ public class EditCommandParserTest {
 
 
         // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditReservationDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        userInput = targetIndex.getOneBased() + TAG_DESC_ANNIVERSARY;
+        descriptor = new EditReservationDescriptorBuilder().withTags(VALID_OCCASION_ANNIVERSARY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -169,9 +169,9 @@ public class EditCommandParserTest {
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // mulltiple valid fields repeated
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_ANNIVERSARY
+                + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_ANNIVERSARY
+                + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_BIRTHDAY;
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));

--- a/src/test/java/seedu/reserve/model/ReserveMateTest.java
+++ b/src/test/java/seedu/reserve/model/ReserveMateTest.java
@@ -3,7 +3,7 @@ package seedu.reserve.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.testutil.Assert.assertThrows;
 import static seedu.reserve.testutil.TypicalReservation.ALICE;
 import static seedu.reserve.testutil.TypicalReservation.getTypicalReserveMate;
@@ -46,7 +46,7 @@ public class ReserveMateTest {
     public void resetData_withDuplicateReservations_throwsDuplicateReservationException() {
         // Two reservations with the same identity fields
         Reservation editedAlice = new ReservationBuilder(ALICE)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY).build();
         List<Reservation> newReservations = Arrays.asList(ALICE, editedAlice);
         ReserveMateStub newData = new ReserveMateStub(newReservations);
 
@@ -73,7 +73,7 @@ public class ReserveMateTest {
     public void hasReservation_reservationWithSameIdentityFieldsInReserveMate_returnsTrue() {
         reserveMate.addReservation(ALICE);
         Reservation editedAlice = new ReservationBuilder(ALICE)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY).build();
         assertTrue(reserveMate.hasReservation(editedAlice));
     }
 

--- a/src/test/java/seedu/reserve/model/reservation/ReservationTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/ReservationTest.java
@@ -7,8 +7,8 @@ import static seedu.reserve.logic.commands.CommandTestUtil.VALID_DATETIME_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_DINERS_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.reserve.testutil.Assert.assertThrows;
 import static seedu.reserve.testutil.TypicalReservation.ALICE;
 import static seedu.reserve.testutil.TypicalReservation.BOB;
@@ -35,7 +35,7 @@ public class ReservationTest {
 
         // same name, phone number and date time, all other attributes different -> returns true
         Reservation editedAlice = new ReservationBuilder(ALICE).withEmail(VALID_EMAIL_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY).build();
         assertTrue(ALICE.isSameReservation(editedAlice));
 
         // different diners, all other attributes same -> returns false
@@ -98,7 +98,7 @@ public class ReservationTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new ReservationBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        editedAlice = new ReservationBuilder(ALICE).withTags(VALID_OCCASION_BIRTHDAY).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 
@@ -106,7 +106,7 @@ public class ReservationTest {
     public void toStringMethod() {
         String expected = Reservation.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone="
                 + ALICE.getPhone() + ", email=" + ALICE.getEmail() + ", diners="
-                + ALICE.getDiners() + ", dateTime=" + ALICE.getDateTime() + ", tags=" + ALICE.getTags() + "}";
+                + ALICE.getDiners() + ", dateTime=" + ALICE.getDateTime() + ", occasion=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/reserve/model/reservation/UniqueReservationListTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/UniqueReservationListTest.java
@@ -3,7 +3,7 @@ package seedu.reserve.model.reservation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.testutil.Assert.assertThrows;
 import static seedu.reserve.testutil.TypicalReservation.ALICE;
 import static seedu.reserve.testutil.TypicalReservation.BOB;
@@ -44,7 +44,7 @@ public class UniqueReservationListTest {
     public void contains_reservationWithSameIdentityFieldsInList_returnsTrue() {
         uniqueReservationList.add(ALICE);
         Reservation editedAlice = new ReservationBuilder(ALICE)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY).build();
         assertTrue(uniqueReservationList.contains(editedAlice));
     }
 
@@ -87,7 +87,7 @@ public class UniqueReservationListTest {
     public void setReservation_editedReservationHasSameIdentity_success() {
         uniqueReservationList.add(ALICE);
         Reservation editedAlice = new ReservationBuilder(ALICE)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_OCCASION_BIRTHDAY).build();
         uniqueReservationList.setReservation(ALICE, editedAlice);
         UniqueReservationList expectedUniqueReservationList = new UniqueReservationList();
         expectedUniqueReservationList.add(editedAlice);

--- a/src/test/java/seedu/reserve/testutil/ReservationUtil.java
+++ b/src/test/java/seedu/reserve/testutil/ReservationUtil.java
@@ -5,7 +5,7 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
 
 import java.util.Set;
 
@@ -37,7 +37,7 @@ public class ReservationUtil {
         sb.append(PREFIX_NUMBER_OF_DINERS + reservation.getDiners().value + " ");
         sb.append(PREFIX_DATE_TIME + reservation.getDateTime().toString() + " ");
         reservation.getTags().stream().forEach(
-            s -> sb.append(PREFIX_TAG + s.tagName + " ")
+            s -> sb.append(PREFIX_OCCASION + s.tagName + " ")
         );
         return sb.toString();
     }
@@ -60,9 +60,9 @@ public class ReservationUtil {
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_OCCASION);
             } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(PREFIX_OCCASION).append(s.tagName).append(" "));
             }
         }
         return sb.toString();

--- a/src/test/java/seedu/reserve/testutil/ReservationUtil.java
+++ b/src/test/java/seedu/reserve/testutil/ReservationUtil.java
@@ -4,8 +4,8 @@ import static seedu.reserve.logic.parser.CliSyntax.PREFIX_DATE_TIME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_NUMBER_OF_DINERS;
-import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.reserve.logic.parser.CliSyntax.PREFIX_OCCASION;
+import static seedu.reserve.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Set;
 

--- a/src/test/java/seedu/reserve/testutil/TypicalReservation.java
+++ b/src/test/java/seedu/reserve/testutil/TypicalReservation.java
@@ -6,10 +6,10 @@ import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_ANNIVERSARY;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.reserve.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,10 +91,10 @@ public class TypicalReservation {
 
     // Manually added - Reservation's details found in {@code CommandTestUtil}
     public static final Reservation AMY = new ReservationBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withTags(VALID_OCCASION_ANNIVERSARY).build();
     public static final Reservation BOB = new ReservationBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withDiners(VALID_DINERS_BOB)
-            .withDateTime(VALID_DATETIME_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withDateTime(VALID_DATETIME_BOB).withTags(VALID_OCCASION_BIRTHDAY, VALID_OCCASION_ANNIVERSARY)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
- The tag parameter has been changed to a compulsory field to improve testing and consistency across reservations. 
- Added and edited test cases to ensure it reflects the updated change in addCommand output
- Refactored t/ prefix to o/ to indicate occasions instead of tags