### PR TITLE
Fix duplicate reservation with customers with the same name

### DIFF
--- a/src/main/java/seedu/reserve/model/reservation/Name.java
+++ b/src/main/java/seedu/reserve/model/reservation/Name.java
@@ -12,12 +12,12 @@ public class Name {
     public static final int MAX_NAME_LENGTH = 50;
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain characters and spaces, should not be blank and not more than 50 characters.";
-
     /*
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
+    public static final String WORDS_REGEX = "\\s+";
     public final String fullName;
 
     /**
@@ -28,7 +28,26 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+        fullName = formatName(name);
+    }
+
+    /**
+     * Formats the given name by capitalising the first letter of each word
+     * and converting the rest to lowercase.
+     *
+     * @param name The user input name string.
+     * @return A formatted name string.
+     */
+    private String formatName(String name) {
+        StringBuilder formattedName = new StringBuilder();
+        String[] nameLowerCase = name.toLowerCase().split(WORDS_REGEX);
+
+        for(String word : nameLowerCase) {
+            formattedName.append(word.toUpperCase().charAt(0));
+            formattedName.append(word.substring(1));
+            formattedName.append(" ");
+        }
+        return formattedName.toString().trim();
     }
 
     /**
@@ -66,7 +85,9 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        String otherFullNameLowerCase = otherName.fullName.toLowerCase();
+        String thisFullName = fullName.toLowerCase();
+        return thisFullName.equals(otherFullNameLowerCase);
     }
 
     @Override

--- a/src/main/java/seedu/reserve/model/reservation/Name.java
+++ b/src/main/java/seedu/reserve/model/reservation/Name.java
@@ -42,7 +42,7 @@ public class Name {
         StringBuilder formattedName = new StringBuilder();
         String[] nameLowerCase = name.toLowerCase().split(WORDS_REGEX);
 
-        for(String word : nameLowerCase) {
+        for (String word : nameLowerCase) {
             formattedName.append(word.toUpperCase().charAt(0));
             formattedName.append(word.substring(1));
             formattedName.append(" ");

--- a/src/test/java/seedu/reserve/model/reservation/NameTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/NameTest.java
@@ -12,12 +12,16 @@ public class NameTest {
     private Name name1;
     private Name name2;
     private Name name3;
+    private Name name4;
+    private Name name5;
 
     @BeforeEach
     public void setUp() {
         name1 = new Name("Valid Name");
         name2 = new Name("Valid Name");
         name3 = new Name("Another Valid Name");
+        name4 = new Name("JohN DoE");
+        name5 = new Name("jOhN DoE");
     }
 
     @Test
@@ -30,6 +34,7 @@ public class NameTest {
         String invalidName = "";
         assertThrows(IllegalArgumentException.class, () -> new Name(invalidName));
     }
+
 
     @Test
     public void isValidName() {
@@ -58,6 +63,9 @@ public class NameTest {
 
     @Test
     public void equals() {
+
+        // same value, different capitalization -> True
+        assertEquals(name5, name4);
 
         // same values -> returns true
         assertTrue(name1.equals(name2));

--- a/src/test/java/seedu/reserve/model/reservation/ReservationTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/ReservationTest.java
@@ -38,6 +38,15 @@ public class ReservationTest {
                 .withTags(VALID_OCCASION_BIRTHDAY).build();
         assertTrue(ALICE.isSameReservation(editedAlice));
 
+        // name differs in case, all other attributes same -> returns True
+        Reservation editedBob = new ReservationBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSameReservation(editedBob));
+
+        // name has trailing spaces, all other attributes same -> returns false
+        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
+        editedBob = new ReservationBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        assertTrue(BOB.isSameReservation(editedBob));
+
         // different diners, all other attributes same -> returns false
         editedAlice = new ReservationBuilder(ALICE).withDiners(VALID_DINERS_BOB).build();
         assertTrue(ALICE.isSameReservation(editedAlice));
@@ -54,18 +63,11 @@ public class ReservationTest {
         editedAlice = new ReservationBuilder(ALICE).withDateTime(VALID_DATETIME_BOB).build();
         assertFalse(ALICE.isSameReservation(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Reservation editedBob = new ReservationBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameReservation(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new ReservationBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameReservation(editedBob));
     }
 
     @Test
     public void equals() {
+
         // same values -> returns true
         Reservation aliceCopy = new ReservationBuilder(ALICE).build();
         assertTrue(ALICE.equals(aliceCopy));


### PR DESCRIPTION
- Added `formatName` to ensure names are capitalization.

Change will not allow for customer with the same name to make duplicate reservation.