### PR TITLE
Fix space issue for phone number

### DIFF
--- a/src/main/java/seedu/reserve/model/reservation/Phone.java
+++ b/src/main/java/seedu/reserve/model/reservation/Phone.java
@@ -12,7 +12,9 @@ public class Phone {
         "Phone numbers should only contain numbers,"
                 + " it should begins with either 8 or 9 and it must be exactly 8 digits long";
     public static final String VALIDATION_REGEX = "[89]\\d{7}";
+    private static String concatPhoneNumber;
     public final String value;
+
 
     /**
      * Constructs a {@code Phone}.
@@ -22,14 +24,14 @@ public class Phone {
     public Phone(String phone) {
         requireNonNull(phone);
         checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
-        value = phone;
+        value = concatPhoneNumber;
     }
 
     /**
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
-        String concatPhoneNumber = test.replaceAll("[^0-9]", "");
+        concatPhoneNumber = test.replaceAll("[^0-9]", "");
         return concatPhoneNumber.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/reserve/model/reservation/Phone.java
+++ b/src/main/java/seedu/reserve/model/reservation/Phone.java
@@ -29,7 +29,8 @@ public class Phone {
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
-        return test.matches(VALIDATION_REGEX);
+        String concatPhoneNumber = test.replaceAll("[^0-9]", "");
+        return concatPhoneNumber.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/test/java/seedu/reserve/model/reservation/PhoneTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/PhoneTest.java
@@ -30,11 +30,13 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9112234")); // less than 8 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
-        assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("91128765")); // exactly 8 numbers
         assertTrue(Phone.isValidPhone("93121534"));
+        assertTrue(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertTrue(Phone.isValidPhone("9 3 1 2 1 5 3 4")); // spaces within digits
     }
 
     @Test


### PR DESCRIPTION
Allow phone numbers to have spacing.
valid phone numbers: `9 1 2 3 4 5 6 7`, `9123 4567`.

![image](https://github.com/user-attachments/assets/e3d4b504-d15c-41ac-a2d1-02a6cd8ba1b6)
![image](https://github.com/user-attachments/assets/3c45ddf4-d912-446a-baf5-81126fe73377)

Fix #189 