### PR TITLE
Fix leading zeros bug in `Diner` class

### DIFF
--- a/src/main/java/seedu/reserve/model/reservation/Diners.java
+++ b/src/main/java/seedu/reserve/model/reservation/Diners.java
@@ -23,7 +23,19 @@ public class Diners {
     public Diners(String numberOfDiners) {
         requireNonNull(numberOfDiners);
         checkArgument(isValidDiners(numberOfDiners), MESSAGE_CONSTRAINTS);
-        value = numberOfDiners;
+        value = formatDiners(numberOfDiners);
+    }
+
+
+    /**
+     * Format the diners string by removing leading zeros.
+     */
+    private static String formatDiners(String diners) {
+        try {
+            return String.valueOf(Integer.parseInt(diners));
+        } catch (NumberFormatException e) {
+            return diners;
+        }
     }
 
     /**

--- a/src/main/java/seedu/reserve/model/reservation/Diners.java
+++ b/src/main/java/seedu/reserve/model/reservation/Diners.java
@@ -31,11 +31,7 @@ public class Diners {
      * Format the diners string by removing leading zeros.
      */
     private static String formatDiners(String diners) {
-        try {
-            return String.valueOf(Integer.parseInt(diners));
-        } catch (NumberFormatException e) {
-            return diners;
-        }
+        return String.valueOf(Integer.parseInt(diners));
     }
 
     /**

--- a/src/test/java/seedu/reserve/model/reservation/DinersTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/DinersTest.java
@@ -1,5 +1,6 @@
 package seedu.reserve.model.reservation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.testutil.Assert.assertThrows;
@@ -17,6 +18,17 @@ public class DinersTest {
     public void constructor_invalidDiners_throwsIllegalArgumentException() {
         String invalidDiner = "1000";
         assertThrows(IllegalArgumentException.class, () -> new Diners(invalidDiner));
+    }
+
+    @Test
+    public void constructor_removeLeadingZeros_success() {
+        // Remove leading zero
+        assertEquals("1", new Diners("00001").value);
+        assertEquals("5", new Diners("005").value);
+        assertEquals("10", new Diners("010").value);
+
+        assertEquals("1", new Diners("1").value);
+        assertEquals("10", new Diners("10").value);
     }
 
     @Test


### PR DESCRIPTION
Remove leading zeros. input: `edit 1 x/00010`.

![image](https://github.com/user-attachments/assets/b3ef589c-df9e-4af3-b4c6-686b0be7a008)
![image](https://github.com/user-attachments/assets/41e40a91-fb36-41e1-9204-5d910b5a46e3)
