### PR TITLE
List command - fix Invalid command format

### DIFF
--- a/src/main/java/seedu/reserve/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/ClearCommand.java
@@ -43,9 +43,8 @@ public class ClearCommand extends Command {
      *
      * @param trimmedArgs The user input argument after trimming spaces.
      * @return {@code true} if the argument is valid, {@code false} otherwise.
-     * @throws ParseException If the confirmation argument contains multiple words.
      */
-    public static boolean isValidConfirm(String trimmedArgs) throws ParseException {
+    public static boolean isValidConfirm(String trimmedArgs) {
         String[] trimmedArgArray = trimmedArgs.split("\\s+");
         if (trimmedArgArray.length > 1) {
             return false;

--- a/src/main/java/seedu/reserve/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/ClearCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 
 import seedu.reserve.logic.commands.exceptions.CommandException;
-import seedu.reserve.logic.parser.exceptions.ParseException;
 import seedu.reserve.model.Model;
 import seedu.reserve.model.ReserveMate;
 import seedu.reserve.model.reservation.Reservation;

--- a/src/main/java/seedu/reserve/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/ListCommand.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import seedu.reserve.logic.Messages;
 import seedu.reserve.logic.commands.exceptions.CommandException;
-import seedu.reserve.logic.parser.exceptions.ParseException;
 import seedu.reserve.model.Model;
 import seedu.reserve.model.reservation.Reservation;
 

--- a/src/main/java/seedu/reserve/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/ListCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.reserve.logic.Messages;
 import seedu.reserve.logic.commands.exceptions.CommandException;
+import seedu.reserve.logic.parser.exceptions.ParseException;
 import seedu.reserve.model.Model;
 import seedu.reserve.model.reservation.Reservation;
 
@@ -18,6 +19,22 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all reservations";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists all reservations in the reservation book.\n"
+            + "Example: " + COMMAND_WORD;
+
+    /**
+     * Validates whether the input arguments for the ListCommand are correct.
+     *
+     * @param args The input arguments provided by the user.
+     * @return {@code true} if the arguments are valid (empty input), {@code false} otherwise.
+     */
+    public static boolean isValidListCommand(String args) {
+        String trimmedArgs = args.trim();
+        return trimmedArgs.isEmpty();
+    }
+
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -34,4 +51,14 @@ public class ListCommand extends Command {
         model.updateFilteredReservationList(PREDICATE_SHOW_ALL_RESERVATIONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        return other instanceof ListCommand;
+    }
+
 }

--- a/src/main/java/seedu/reserve/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/ListCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.reserve.logic.parser;
+
+import static seedu.reserve.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.reserve.logic.commands.ListCommand;
+import seedu.reserve.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code ListCommand} object.
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments and returns a {@code ListCommand} object for execution.
+     *
+     * @param args The user input arguments for the list command.
+     * @return A new {@code ListCommand} instance if the input is valid.
+     * @throws ParseException If the user input does not conform to the expected format.
+     */
+    public ListCommand parse(String args) throws ParseException {
+        try {
+            boolean isValid = ListCommand.isValidListCommand(args);
+            if (!isValid) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+            }
+            return new ListCommand();
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/reserve/logic/parser/ReserveMateParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/ReserveMateParser.java
@@ -74,7 +74,7 @@ public class ReserveMateParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/test/java/seedu/reserve/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/ListCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.reserve.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.reserve.logic.commands.CommandTestUtil.showReservationAtIndex;
@@ -46,5 +48,51 @@ public class ListCommandTest {
 
         // Check for CommandException
         assertCommandFailure(new ListCommand(), emptyModel, Messages.MESSAGE_EMPTY_RESERVATION_LIST);
+    }
+
+    @Test
+    public void equals_sameInstance_returnsTrue() {
+        ListCommand listCommand = new ListCommand();
+        assert(listCommand.equals(listCommand));
+    }
+
+
+    @Test
+    public void equals_differentInstances_returnsTrue() {
+        ListCommand listCommand1 = new ListCommand();
+        ListCommand listCommand2 = new ListCommand();
+        assert(listCommand1.equals(listCommand2));
+    }
+
+
+    @Test
+    public void equals_differentObject_returnsFalse() {
+        ListCommand listCommand = new ListCommand();
+        Object other = new Object();
+        assert(!listCommand.equals(other));
+    }
+
+    @Test
+    public void isValidListCommand_validInputs_returnsTrue() {
+        // Empty input (valid case)
+        assertTrue(ListCommand.isValidListCommand(""));
+
+        // Input with spaces only (still valid because it trims)
+        assertTrue(ListCommand.isValidListCommand("   "));
+    }
+
+    @Test
+    public void isValidListCommand_invalidInputs_returnsFalse() {
+        // Non-empty text input
+        assertFalse(ListCommand.isValidListCommand("abc"));
+
+        // Random special characters
+        assertFalse(ListCommand.isValidListCommand("@!#"));
+
+        // Combination of spaces and text
+        assertFalse(ListCommand.isValidListCommand(" list "));
+
+        // Numeric values
+        assertFalse(ListCommand.isValidListCommand("123"));
     }
 }

--- a/src/test/java/seedu/reserve/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ListCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.reserve.logic.parser;
+
+import static seedu.reserve.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.reserve.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.reserve.logic.commands.ListCommand;
+
+/**
+ * Unit tests for {@code ListCommandParser}.
+ */
+public class ListCommandParserTest {
+
+    private final ListCommandParser parser = new ListCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsListCommand() {
+        assertParseSuccess(parser, "", new ListCommand()); // Assuming empty input is valid
+    }
+
+    @Test
+    public void parse_whitespaceArgs_returnsListCommand() {
+        assertParseSuccess(parser, "  ", new ListCommand()); // Assuming spaces are ignored and valid
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "invalid_input", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nullArgs_throwsParseException() {
+        assertParseFailure(parser, "123", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/reserve/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ListCommandParserTest.java
@@ -27,7 +27,8 @@ public class ListCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "invalid_input", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "invalid_input",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
This PR introduces enhancements to the ListCommand functionality by adding:

-A new isValidListCommand method for validating command inputs.
- A ListCommandParser class to properly handle parsing logic.
- Unit tests for isValidListCommand and ListCommandParser.

Changes Made
- Added isValidListCommand in ListCommand
- Ensures that the command is valid only when no extra arguments are provided.
- Returns true for empty input or spaces, false otherwise.
- Includes unit tests to validate edge cases.

Created ListCommandParser
- Implements the parsing logic for ListCommand.
- Rejects invalid inputs and throws ParseException when necessary.
- Ensures the list command is correctly processed.
- Refactored ListCommandTest
- Added test cases for isValidListCommand.
- Ensured proper behavior for empty, whitespace, and invalid inputs.

Fixes #180 