### PR TITLE
Fix ClearCommand message issue

### DIFF
--- a/src/main/java/seedu/reserve/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/ClearCommand.java
@@ -20,10 +20,12 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Reservation book has been cleared!";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Clears all reservations from the reservation book.\n"
-            + "Parameters: cfm must be provided to confirm the action\n"
+            + "Parameters: 'cfm' must be provided to confirm the action\n"
+            + "Keyword 'cfm' is case sensitive\n"
             + "Example: " + COMMAND_WORD + " cfm";
     public static final String MESSAGE_ADD_CONFIRM_CLEAR_RESERVATION =
-            "Are you sure you want to clear ALL reservations? Type 'clear cfm'";
+            "Are you sure you want to clear ALL reservations? Type 'clear cfm'\n"
+        + "Keyword 'cfm' is case sensitive";
     public static final String MESSAGE_NO_RESERVATIONS_TO_CLEAR =
             "Reservation List is empty. No reservations found to clear!";
 


### PR DESCRIPTION
Added an extra line in ClearCommand messages to let the user know that keyword 'cfm' is case sensitive.

![telegram-cloud-photo-size-5-6287303535880161913-x](https://github.com/user-attachments/assets/fd0d6d0b-3abc-4747-8c9c-78faf424db73)

![telegram-cloud-photo-size-5-6287303535880161914-x](https://github.com/user-attachments/assets/5e614dbf-af48-4a9f-b159-076267a270ab)


Fixes #166 