### PR TITLE
Fix DeleteCommand format issue

### DIFF
--- a/src/main/java/seedu/reserve/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/DeleteCommand.java
@@ -75,7 +75,7 @@ public class DeleteCommand extends Command {
         Reservation reservationToDelete = lastShownList.get(targetIndex.getZeroBased());
 
         if (!isConfirmed) {
-            return new CommandResult(String.format(MESSAGE_CONFIRM_DELETE, this.targetIndex.getOneBased()));
+            throw new CommandException(String.format(MESSAGE_CONFIRM_DELETE, this.targetIndex.getOneBased()));
         }
 
         model.deleteReservation(reservationToDelete);

--- a/src/test/java/seedu/reserve/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/DeleteCommandTest.java
@@ -147,7 +147,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getReserveMate(), new UserPrefs());
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(deleteCommand, expectedModel, expectedMessage);
     }
 
 }


### PR DESCRIPTION
Fix deleteCommand invalid command format issue by throwing new ComandException instead of returning a new CommandResult.

This allows the user to not need to retype the whole command but just needing to backspace to retype what he/she typed wrongly.

![image](https://github.com/user-attachments/assets/887614f1-8a56-477f-a6c6-8c43275a2c30)

Fixes #185 