### PR TITLE
Branch bug duplicate reservation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -328,7 +328,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL x/NUMBER_OF_DINER d/DATE_TIME [o/OCCA
 > **Input**: `add n/John Doe p/98765432 e/johnd@example.com x/5 d/2025-04-12 1800 o/BIRTHDAY`
 >
 > **Output**:
-> ``` This reservation already exists in the reservation book ```
+> ```"A reservation already exists for this customer (same email or phone) at the chosen date-time.```
 >
 > ---
 ---

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -328,7 +328,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL x/NUMBER_OF_DINER d/DATE_TIME [o/OCCA
 > **Input**: `add n/John Doe p/98765432 e/johnd@example.com x/5 d/2025-04-12 1800 o/BIRTHDAY`
 >
 > **Output**:
-> ```"A reservation already exists for this customer (same email or phone) at the chosen date-time.```
+> ```A reservation already exists for this customer (same email or phone) at the chosen date-time.```
 >
 > ---
 ---

--- a/src/main/java/seedu/reserve/logic/Messages.java
+++ b/src/main/java/seedu/reserve/logic/Messages.java
@@ -23,6 +23,8 @@ public class Messages {
             "No reservations found. Use the 'add' command to create a reservation\n"
                     + "or 'help' to view all commands.";
     public static final String MESSAGE_NO_RESERVATIONS = "No reservations found.";
+    public static final String MESSAGE_DUPLICATE_RESERVATION =
+            "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/reserve/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/AddCommand.java
@@ -39,7 +39,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New reservation added: %1$s";
     public static final String MESSAGE_DUPLICATE_RESERVATION =
-            "This reservation already exists in the reservation book";
+            "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
     public static final String MESSAGE_NO_OCCASION = "Please indicate an occasion \n"
         + "Example: " + PREFIX_OCCASION + "Birthday \n"
         + "Example: " + PREFIX_OCCASION + "None";

--- a/src/main/java/seedu/reserve/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/AddCommand.java
@@ -36,10 +36,7 @@ public class AddCommand extends Command {
             + PREFIX_NUMBER_OF_DINERS + "5 "
             + PREFIX_DATE_TIME + "2026-12-31 1800 "
             + PREFIX_OCCASION + "Birthday ";
-
     public static final String MESSAGE_SUCCESS = "New reservation added: %1$s";
-    public static final String MESSAGE_DUPLICATE_RESERVATION =
-            "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
     public static final String MESSAGE_NO_OCCASION = "Please indicate an occasion \n"
         + "Example: " + PREFIX_OCCASION + "Birthday \n"
         + "Example: " + PREFIX_OCCASION + "None";
@@ -59,7 +56,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasReservation(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_RESERVATION);
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_RESERVATION);
         }
 
         if (toAdd.getTags().isEmpty()) {

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -57,7 +57,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_RESERVATION_SUCCESS = "Edited Reservation: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_RESERVATION =
-            "This reservation already exists in the reservation book.";
+            "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
     public static final String MESSAGE_FUTURE_RESERVATION_REQUIRED = "Past reservation cannot be edited.";
 
 

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -56,8 +56,6 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_RESERVATION_SUCCESS = "Edited Reservation: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_RESERVATION =
-            "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
     public static final String MESSAGE_FUTURE_RESERVATION_REQUIRED = "Past reservation cannot be edited.";
 
 
@@ -104,7 +102,7 @@ public class EditCommand extends Command {
         }
 
         if (!reservationToEdit.isSameReservation(editedReservation) && model.hasReservation(editedReservation)) {
-            throw new CommandException(MESSAGE_DUPLICATE_RESERVATION);
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_RESERVATION);
 
         }
 

--- a/src/main/java/seedu/reserve/model/reservation/Reservation.java
+++ b/src/main/java/seedu/reserve/model/reservation/Reservation.java
@@ -109,8 +109,8 @@ public class Reservation {
         }
 
         return otherReservation != null
-                && otherReservation.getName().equals(getName())
-                && otherReservation.getPhone().equals(getPhone())
+                && (otherReservation.getEmail().equals(getEmail())
+                || otherReservation.getPhone().equals(getPhone()))
                 && otherReservation.getDateTime().equals(getDateTime());
     }
 

--- a/src/test/java/seedu/reserve/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/AddCommandIntegrationTest.java
@@ -42,7 +42,7 @@ public class AddCommandIntegrationTest {
     public void execute_duplicateReservation_throwsCommandException() {
         Reservation reservationInList = model.getReserveMate().getReservationList().get(0);
         assertCommandFailure(new AddCommand(reservationInList), model,
-                AddCommand.MESSAGE_DUPLICATE_RESERVATION);
+                Messages.MESSAGE_DUPLICATE_RESERVATION);
     }
 
 }

--- a/src/test/java/seedu/reserve/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/AddCommandTest.java
@@ -51,7 +51,7 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validReservation);
         ModelStub modelStub = new ModelStubWithReservation(validReservation);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_RESERVATION, ()
+        assertThrows(CommandException.class, Messages.MESSAGE_DUPLICATE_RESERVATION, ()
                 -> addCommand.execute(modelStub));
     }
 

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -137,7 +137,7 @@ public class EditCommandTest {
                 new EditReservationDescriptorBuilder(firstReservation).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_RESERVATION, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_RESERVATION);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_RESERVATION);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_RESERVATION,
                 new EditReservationDescriptorBuilder(reservationInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_RESERVATION);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_RESERVATION);
     }
 
     @Test

--- a/src/test/java/seedu/reserve/model/reservation/ReservationTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/ReservationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_DATETIME_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_DINERS_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_OCCASION_BIRTHDAY;
 import static seedu.reserve.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -51,16 +52,33 @@ public class ReservationTest {
         editedAlice = new ReservationBuilder(ALICE).withDiners(VALID_DINERS_BOB).build();
         assertTrue(ALICE.isSameReservation(editedAlice));
 
-        // different name, all other attributes same -> returns false
+        // different name, all other attributes same -> returns true
         editedAlice = new ReservationBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSameReservation(editedAlice));
+        assertTrue(ALICE.isSameReservation(editedAlice));
 
-        // different phone number, all other attributes same -> returns false
+
+        // Same email, different name, all other attributes same -> returns true
+        editedAlice = new ReservationBuilder(ALICE)
+                .withName(VALID_NAME_BOB)
+                .build();
+        assertTrue(ALICE.isSameReservation(editedAlice));
+
+        // Same phone, different email -> returns true
+        editedAlice = new ReservationBuilder(ALICE)
+                .withEmail(VALID_EMAIL_BOB)
+                .build();
+        assertTrue(ALICE.isSameReservation(editedAlice));
+
+        // different phone number, all other attributes same -> returns true
         editedAlice = new ReservationBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
-        assertFalse(ALICE.isSameReservation(editedAlice));
+        assertTrue(ALICE.isSameReservation(editedAlice));
 
         // different date and time, all other attributes same -> returns false
         editedAlice = new ReservationBuilder(ALICE).withDateTime(VALID_DATETIME_BOB).build();
+        assertFalse(ALICE.isSameReservation(editedAlice));
+
+        // different date and time, different name, all other attributes same -> returns false
+        editedAlice = new ReservationBuilder(ALICE).withDateTime(VALID_DATETIME_BOB).withName(VALID_NAME_AMY).build();
         assertFalse(ALICE.isSameReservation(editedAlice));
 
     }


### PR DESCRIPTION
Change the duplicate reservation validation. Prevents duplicate bookings for the same customer.

A reservation is considered a duplicate if:
-It has the same date/time, AND It has the same email OR same phone number as an existing reservation.

![image](https://github.com/user-attachments/assets/398aac2f-0632-4b9e-94fe-4fd7d5db1877)

![image](https://github.com/user-attachments/assets/691d5593-a9b8-4860-9768-eabd5c978016)

Seqeuence of inputs:
`add n/John Doe p/98765432 e/johnd@example.com x/5 d/2025-04-22 1800 o/Birthday ` - add to reservation
`add n/John Doe p/98765432 e/johnd@example.com x/5 d/2025-04-22 1800 o/Birthday ` - error message same phone, email and date-time
`add n/John Doe p/88888888 e/johnd@example.com x/5 d/2025-04-22 1800 o/Birthday ` - error message same email and date-time
`add n/John Doe p/98765432 e/Another@example.com x/5 d/2025-04-22 1800 o/Birthday ` - error message same phone and date -time
