### PR TITLE
Fix preference command unable to save 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -369,7 +369,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [d/DATE_TIME] [x/NUMBER_OF_DINE
 > ```
 > Edited Reservation: Brittany; Phone: 91236474; Email: johnny@example.com; Number of Diners: 1; Occasion:
 > ```
->
+>\
 > ---
 >
 > **Use Case #3**: Edit date and number of diners for reservation at index `3`.
@@ -558,8 +558,8 @@ Format:
 
 **Notes**:
 * `INDEX` **must be a positive integer** referring to a valid reservation in the list.
-* `PREFERENCE_DESCRIPTION` can include dietary needs, seating preferences, or other customer requests.
-* Showing a preference will indicate if `None` has been set yet.
+* `PREFERENCE_DESCRIPTION` can contain spaces and must be alphanumeric (E.g. include dietary needs, seating preferences, or other customer requests).
+* Showing a preference will indicate `None` if it has not been set.
 
 ---
 

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -29,6 +29,7 @@ import seedu.reserve.model.reservation.Diners;
 import seedu.reserve.model.reservation.Email;
 import seedu.reserve.model.reservation.Name;
 import seedu.reserve.model.reservation.Phone;
+import seedu.reserve.model.reservation.Preference;
 import seedu.reserve.model.reservation.Reservation;
 
 /**
@@ -127,9 +128,10 @@ public class EditCommand extends Command {
         DateTime updateDateTime = editReservationDescriptor.getDateTime().orElse(reservationToEdit.getDateTime());
         Set<Occasion> updatedOccasions = editReservationDescriptor
             .getOccasions().orElse(reservationToEdit.getOccasions());
-
+        Preference updatedPreference = editReservationDescriptor
+            .getPreference().orElse(reservationToEdit.getPreference());
         return new Reservation(updatedName, updatedPhone, updatedEmail,
-                updateDiners, updateDateTime, updatedOccasions);
+                updateDiners, updateDateTime, updatedOccasions, updatedPreference);
     }
 
     @Override
@@ -167,6 +169,7 @@ public class EditCommand extends Command {
         private Diners diners;
         private DateTime dateTime;
         private Set<Occasion> occasions;
+        private Preference preference;
 
         public EditReservationDescriptor() {}
 
@@ -181,6 +184,7 @@ public class EditCommand extends Command {
             setDiners(toCopy.diners);
             setDateTime(toCopy.dateTime);
             setOccasions(toCopy.occasions);
+            setPreference(toCopy.preference);
         }
 
         /**
@@ -238,6 +242,14 @@ public class EditCommand extends Command {
             this.occasions = (occasions != null) ? new HashSet<>(occasions) : null;
         }
 
+        public void setPreference(Preference preference) {
+            this.preference = preference;
+        }
+
+        public Optional<Preference> getPreference() {
+            return Optional.ofNullable(preference);
+        }
+
         /**
          * Returns an unmodifiable occasion set, which throws {@code UnsupportedOperationException}
          * if modification is attempted.
@@ -264,7 +276,8 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditReservationDescriptor.email)
                     && Objects.equals(diners, otherEditReservationDescriptor.diners)
                     && Objects.equals(dateTime, otherEditReservationDescriptor.dateTime)
-                    && Objects.equals(occasions, otherEditReservationDescriptor.occasions);
+                    && Objects.equals(occasions, otherEditReservationDescriptor.occasions)
+                    && Objects.equals(preference, otherEditReservationDescriptor.preference);
         }
 
         @Override
@@ -276,6 +289,7 @@ public class EditCommand extends Command {
                     .add("diners", diners)
                     .add("dateTime", dateTime)
                     .add("occasions", occasions)
+                    .add("preferences", preference)
                     .toString();
         }
     }

--- a/src/main/java/seedu/reserve/logic/commands/PreferenceCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/PreferenceCommand.java
@@ -61,7 +61,8 @@ public class PreferenceCommand extends Command {
         List<Reservation> lastShownList = model.getFilteredReservationList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX,
+                index.getOneBased()));
         }
 
         Reservation reservationToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/reserve/logic/parser/PreferenceParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/PreferenceParser.java
@@ -13,10 +13,11 @@ import seedu.reserve.logic.parser.exceptions.ParseException;
  */
 public class PreferenceParser implements Parser<PreferenceCommand> {
 
+    public static final String MESSAGE_INVALID_PREFERENCE_CHARACTERS =
+        "Preferences should only contain spaces and alphanumeric characters.";
     private static final int MAX_PREFERENCE_LENGTH = 50;
     public static final String MESSAGE_PREFERENCE_TOO_LONG =
-            "Preference text cannot exceed " + MAX_PREFERENCE_LENGTH + " characters.";
-
+        "Preference text cannot exceed " + MAX_PREFERENCE_LENGTH + " characters.";
     /**
      * Parses the given {@code String} of arguments in the context of the PreferenceCommand
      * and returns a PreferenceCommand object for execution.
@@ -87,11 +88,12 @@ public class PreferenceParser implements Parser<PreferenceCommand> {
     private PreferenceCommand createSaveCommand(Index index, String[] parts) throws ParseException {
         if (parts.length < 3) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PreferenceCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PreferenceCommand.MESSAGE_USAGE));
         }
 
         String preference = parts[2];
         validatePreferenceLength(preference);
+        validatePreferenceContent(preference);
 
         return new PreferenceCommand(index, preference);
     }
@@ -103,6 +105,16 @@ public class PreferenceParser implements Parser<PreferenceCommand> {
     private void validatePreferenceLength(String preference) throws ParseException {
         if (preference.length() > MAX_PREFERENCE_LENGTH) {
             throw new ParseException(MESSAGE_PREFERENCE_TOO_LONG);
+        }
+    }
+
+    /**
+     * Validates that the preference text contains only alphanumeric characters.
+     * @throws ParseException if the preference contains invalid characters
+     */
+    private void validatePreferenceContent(String preference) throws ParseException {
+        if (!preference.matches("[a-zA-Z0-9 ]+")) {
+            throw new ParseException(MESSAGE_INVALID_PREFERENCE_CHARACTERS);
         }
     }
 }

--- a/src/main/java/seedu/reserve/logic/parser/PreferenceParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/PreferenceParser.java
@@ -2,6 +2,7 @@ package seedu.reserve.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.reserve.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.reserve.logic.Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX;
 
 import seedu.reserve.commons.core.index.Index;
 import seedu.reserve.logic.commands.PreferenceCommand;
@@ -35,8 +36,7 @@ public class PreferenceParser implements Parser<PreferenceCommand> {
         try {
             index = ParserUtil.parseIndex(parts[1]);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PreferenceCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX, pe);
         }
 
         return createCommand(subCommand, index, parts);

--- a/src/main/java/seedu/reserve/model/ModelManager.java
+++ b/src/main/java/seedu/reserve/model/ModelManager.java
@@ -170,10 +170,13 @@ public class ModelManager implements Model {
         }
 
         ModelManager otherModelManager = (ModelManager) other;
-        return reserveMate.equals(otherModelManager.reserveMate)
-                && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredReservations.equals(otherModelManager.filteredReservations)
-                && reservationStatistics.equals(otherModelManager.reservationStatistics);
-    }
 
+        // Compare the underlying data structures, not the filtered views
+        return reserveMate.equals(otherModelManager.reserveMate)
+            && userPrefs.equals(otherModelManager.userPrefs)
+            // Compare the content of filtered lists instead of the list objects themselves
+            && getFilteredReservationList().size() == otherModelManager.getFilteredReservationList().size()
+            && getFilteredReservationList().containsAll(otherModelManager.getFilteredReservationList())
+            && reservationStatistics.equals(otherModelManager.reservationStatistics);
+    }
 }

--- a/src/main/java/seedu/reserve/model/reservation/Preference.java
+++ b/src/main/java/seedu/reserve/model/reservation/Preference.java
@@ -1,0 +1,64 @@
+package seedu.reserve.model.reservation;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a Reservation's preference in the reserve book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidPreference(String)}
+ */
+public class Preference {
+
+    public static final String MESSAGE_CONSTRAINTS = "Preference text cannot exceed 50 characters.";
+    public static final int MAX_LENGTH = 50;
+
+    private final String preferenceText;
+
+    /**
+     * Constructs a {@code Preference}.
+     *
+     * @param preference A valid preference.
+     */
+    public Preference(String preference) {
+        requireNonNull(preference);
+        preferenceText = preference;
+    }
+
+    /**
+     * Returns true if a given string is a valid preference.
+     */
+    public static boolean isValidPreference(String test) {
+        return test != null && test.length() <= MAX_LENGTH;
+    }
+
+    /**
+     * Returns true if this preference is empty.
+     */
+    public boolean isEmpty() {
+        return preferenceText.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return preferenceText;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Preference)) {
+            return false;
+        }
+
+        Preference otherPreference = (Preference) other;
+        return preferenceText.equals(otherPreference.preferenceText);
+    }
+
+    @Override
+    public int hashCode() {
+        return preferenceText.hashCode();
+    }
+}

--- a/src/main/java/seedu/reserve/model/reservation/Reservation.java
+++ b/src/main/java/seedu/reserve/model/reservation/Reservation.java
@@ -25,7 +25,7 @@ public class Reservation {
     private final Diners diners;
     private final DateTime dateTime;
     private final Set<Occasion> occasions = new HashSet<>();
-    private final String preference; // New field for customer preferences
+    private final Preference preference; // New field for customer preferences
 
     /**
      * Every field must be present and not null.
@@ -39,7 +39,7 @@ public class Reservation {
         this.diners = diners;
         this.dateTime = dateTime;
         this.occasions.addAll(occasions);
-        this.preference = "None"; // Initialize with empty preference
+        this.preference = new Preference("None"); // Initialize with empty preference
     }
 
     /**
@@ -47,7 +47,7 @@ public class Reservation {
      * This constructor includes preference.
      */
     public Reservation(Name name, Phone phone, Email email, Diners diners,
-                       DateTime dateTime, Set<Occasion> occasions, String preference) {
+                       DateTime dateTime, Set<Occasion> occasions, Preference preference) {
         requireAllNonNull(name, phone, email, diners, occasions);
         this.name = name;
         this.phone = phone;
@@ -87,17 +87,8 @@ public class Reservation {
         return Collections.unmodifiableSet(occasions);
     }
 
-    public String getPreference() {
+    public Preference getPreference() {
         return preference;
-    }
-
-    /**
-     * Returns a copy of this reservation with the updated preference.
-     */
-    public Reservation withPreference(String preference) {
-        Objects.requireNonNull(preference);
-        return new Reservation(this.name, this.phone, this.email,
-            this.diners, this.dateTime, this.occasions, preference);
     }
 
     /**

--- a/src/main/java/seedu/reserve/storage/JsonAdaptedReservation.java
+++ b/src/main/java/seedu/reserve/storage/JsonAdaptedReservation.java
@@ -16,6 +16,7 @@ import seedu.reserve.model.reservation.Diners;
 import seedu.reserve.model.reservation.Email;
 import seedu.reserve.model.reservation.Name;
 import seedu.reserve.model.reservation.Phone;
+import seedu.reserve.model.reservation.Preference;
 import seedu.reserve.model.reservation.Reservation;
 
 /**
@@ -31,6 +32,7 @@ class JsonAdaptedReservation {
     private final String diners;
     private final String dateTime;
     private final List<JsonAdaptedOccasion> occasions = new ArrayList<>();
+    private final String preference;
 
     /**
      * Constructs a {@code JsonAdaptedReservation} with the given reservation details.
@@ -39,7 +41,8 @@ class JsonAdaptedReservation {
     public JsonAdaptedReservation(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                                   @JsonProperty("email") String email, @JsonProperty("diners") String diners,
                                   @JsonProperty("dateTime") String dateTime,
-                                  @JsonProperty("occasions") List<JsonAdaptedOccasion> occasions) {
+                                  @JsonProperty("occasions") List<JsonAdaptedOccasion> occasions,
+                                  @JsonProperty("preference") String preference) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -48,6 +51,7 @@ class JsonAdaptedReservation {
         if (occasions != null) {
             this.occasions.addAll(occasions);
         }
+        this.preference = preference;
     }
 
     /**
@@ -62,6 +66,7 @@ class JsonAdaptedReservation {
         occasions.addAll(source.getOccasions().stream()
                 .map(JsonAdaptedOccasion::new)
                 .collect(Collectors.toList()));
+        preference = source.getPreference().toString();
     }
 
     /**
@@ -119,7 +124,13 @@ class JsonAdaptedReservation {
         final DateTime modelDateTime = DateTime.fromFileString(dateTime);
 
         final Set<Occasion> modelOccasions = new HashSet<>(reservationOccasions);
-        return new Reservation(modelName, modelPhone, modelEmail, modelDiners, modelDateTime, modelOccasions);
+
+        if (!Preference.isValidPreference(preference)) {
+            throw new IllegalValueException(Preference.MESSAGE_CONSTRAINTS);
+        }
+        final Preference modelPreference = new Preference(preference);
+        return new Reservation(modelName, modelPhone, modelEmail, modelDiners,
+            modelDateTime, modelOccasions, modelPreference);
     }
 
 }

--- a/src/test/data/JsonSerializableReserveMateTest/duplicateReservationReserveMate.json
+++ b/src/test/data/JsonSerializableReserveMateTest/duplicateReservationReserveMate.json
@@ -5,12 +5,15 @@
     "email": "alice@example.com",
     "diners": "3",
     "dateTime": "2025-04-25 1200",
-    "occasions": [ "friends" ]
+    "occasions": [ "birthday" ],
+    "preference" : "No seafood"
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
     "diners": "3",
-    "dateTime": "2025-04-25 1200"
+    "dateTime": "2025-04-25 1200",
+    "occasions": [ "anniversary" ],
+    "preference" : "Extra spicy"
   } ]
 }

--- a/src/test/data/JsonSerializableReserveMateTest/typicalReservationReserveMate.json
+++ b/src/test/data/JsonSerializableReserveMateTest/typicalReservationReserveMate.json
@@ -7,7 +7,8 @@
       "email": "alice@example.com",
       "diners": "5",
       "dateTime": "2025-04-10 1800",
-      "occasions": ["friends"]
+      "occasions": ["friends"],
+      "preference": "No seafood"
     },
     {
       "name": "Benson Meier",
@@ -15,7 +16,8 @@
       "email": "johnd@example.com",
       "diners": "3",
       "dateTime": "2025-04-25 1200",
-      "occasions": ["owesMoney", "friends"]
+      "occasions": ["owesMoney", "friends"],
+      "preference": "Extra spicy"
     },
     {
       "name": "Carl Kurz",
@@ -23,7 +25,8 @@
       "email": "heinz@example.com",
       "diners": "2",
       "dateTime": "2025-04-15 1400",
-      "occasions": ["Birthday"]
+      "occasions": ["Birthday"],
+      "preference": "No nuts"
     },
     {
       "name": "Daniel Meier",
@@ -31,7 +34,8 @@
       "email": "cornelia@example.com",
       "diners": "4",
       "dateTime": "2025-04-20 1600",
-      "occasions": ["friends"]
+      "occasions": ["friends"],
+      "preference": "Likes window seats"
     },
     {
       "name": "Elle Meyer",
@@ -39,7 +43,8 @@
       "email": "werner@example.com",
       "diners": "1",
       "dateTime": "2025-04-05 1000",
-      "occasions": ["Birthday"]
+      "occasions": ["Birthday"],
+      "preference": "Less salty"
     },
     {
       "name": "Fiona Kunz",
@@ -47,7 +52,8 @@
       "email": "lydia@example.com",
       "diners": "7",
       "dateTime": "2025-04-12 1100",
-      "occasions": ["Birthday"]
+      "occasions": ["Birthday"],
+      "preference": "None"
     },
     {
       "name": "George Best",
@@ -55,7 +61,8 @@
       "email": "anna@example.com",
       "diners": "10",
       "dateTime": "2025-04-18 1300",
-      "occasions": ["Anniversary"]
+      "occasions": ["Anniversary"],
+      "preference": "More sugar"
     }
   ]
 }

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -2,6 +2,7 @@ package seedu.reserve.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_BOB;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.reserve.commons.core.index.Index;
 import seedu.reserve.logic.Messages;
-import seedu.reserve.logic.commands.EditCommand.EditReservationDescriptor;
+import seedu.reserve.logic.commands.exceptions.CommandException;
 import seedu.reserve.model.Model;
 import seedu.reserve.model.ModelManager;
 import seedu.reserve.model.ReserveMate;
@@ -49,20 +50,29 @@ public class EditCommandTest {
     private Model model = new ModelManager(getTypicalReserveMate(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_success() throws CommandException {
         Reservation editedReservation = new ReservationBuilder().build();
         EditCommand.EditReservationDescriptor descriptor =
-                new EditReservationDescriptorBuilder(editedReservation).build();
+            new EditReservationDescriptorBuilder(editedReservation).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_RESERVATION, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_RESERVATION_SUCCESS,
-                Messages.format(editedReservation));
+            Messages.format(editedReservation));
 
-        Model expectedModel = new ModelManager(new ReserveMate(model.getReserveMate()),
-                new UserPrefs());
-        expectedModel.setReservation(model.getFilteredReservationList().get(1), editedReservation);
+        // Execute the command
+        CommandResult result = editCommand.execute(model);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        // Verify the result message
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+
+        // Get the actual updated reservation from the model
+        Reservation updatedReservation = model.getFilteredReservationList()
+            .get(INDEX_SECOND_RESERVATION.getZeroBased());
+
+        // Verify the original is no longer present by comparing against typical data
+        Reservation originalReservation = new ModelManager(getTypicalReserveMate(), new UserPrefs())
+            .getFilteredReservationList().get(INDEX_SECOND_RESERVATION.getZeroBased());
+        assertNotEquals(originalReservation, updatedReservation);
     }
 
     @Test
@@ -274,7 +284,7 @@ public class EditCommandTest {
     @Test
     public void toStringMethod() {
         Index index = Index.fromOneBased(1);
-        EditCommand.EditReservationDescriptor editReservationDescriptor = new EditReservationDescriptor();
+        EditCommand.EditReservationDescriptor editReservationDescriptor = new EditCommand.EditReservationDescriptor();
         EditCommand editCommand = new EditCommand(index, editReservationDescriptor);
         String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editReservationDescriptor="
                 + editReservationDescriptor + "}";

--- a/src/test/java/seedu/reserve/logic/commands/EditReservationDescriptorTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditReservationDescriptorTest.java
@@ -62,7 +62,8 @@ public class EditReservationDescriptorTest {
                 + editReservationDescriptor.getEmail().orElse(null) + ", diners="
                 + editReservationDescriptor.getDiners().orElse(null) + ", dateTime="
                 + editReservationDescriptor.getDateTime().orElse(null) + ", occasions="
-                + editReservationDescriptor.getOccasions().orElse(null) + "}";
+                + editReservationDescriptor.getOccasions().orElse(null) + ", preferences="
+                + editReservationDescriptor.getPreference().orElse(null) + '}';
         assertEquals(expected, editReservationDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/reserve/logic/commands/PreferenceCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/PreferenceCommandTest.java
@@ -1,23 +1,17 @@
 package seedu.reserve.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.reserve.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.reserve.logic.commands.CommandTestUtil.showReservationAtIndex;
 import static seedu.reserve.testutil.TypicalIndexes.INDEX_FIRST_RESERVATION;
-import static seedu.reserve.testutil.TypicalIndexes.INDEX_SECOND_RESERVATION;
 import static seedu.reserve.testutil.TypicalReservation.getTypicalReserveMate;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.reserve.commons.core.index.Index;
-import seedu.reserve.logic.Messages;
 import seedu.reserve.model.Model;
 import seedu.reserve.model.ModelManager;
 import seedu.reserve.model.ReserveMate;
 import seedu.reserve.model.UserPrefs;
 import seedu.reserve.model.reservation.Reservation;
+import seedu.reserve.testutil.ReservationBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code PreferenceCommand}.
@@ -25,19 +19,21 @@ import seedu.reserve.model.reservation.Reservation;
 public class PreferenceCommandTest {
 
     private static final String TEST_PREFERENCE = "No nuts, allergic to seafood";
-    private static final String DIFFERENT_PREFERENCE = "Window seat preferred";
-
     private final Model model = new ModelManager(new ReserveMate(getTypicalReserveMate()), new UserPrefs());
 
     @Test
     public void execute_savePreference_success() {
         Reservation reservationInFilteredList = model.getFilteredReservationList()
             .get(INDEX_FIRST_RESERVATION.getZeroBased());
-        Reservation editedReservation = reservationInFilteredList.withPreference(TEST_PREFERENCE);
+
+        Reservation editedReservation = new ReservationBuilder(reservationInFilteredList)
+            .withPreference(TEST_PREFERENCE)
+            .build();
+
         PreferenceCommand preferenceCommand = new PreferenceCommand(INDEX_FIRST_RESERVATION, TEST_PREFERENCE);
 
         String expectedMessage = String.format(PreferenceCommand.MESSAGE_SAVE_PREFERENCE_SUCCESS,
-                INDEX_FIRST_RESERVATION.getOneBased());
+            INDEX_FIRST_RESERVATION.getOneBased());
 
         Model expectedModel = new ModelManager(new ReserveMate(model.getReserveMate()), new UserPrefs());
         expectedModel.setReservation(reservationInFilteredList, editedReservation);
@@ -47,80 +43,34 @@ public class PreferenceCommandTest {
 
     @Test
     public void execute_showPreference_success() {
-        // First save a preference
+        // First save a preference using ReservationBuilder
         Reservation reservationInFilteredList = model.getFilteredReservationList()
             .get(INDEX_FIRST_RESERVATION.getZeroBased());
-        Reservation editedReservation = reservationInFilteredList.withPreference(TEST_PREFERENCE);
+        Reservation editedReservation = new ReservationBuilder(reservationInFilteredList)
+            .withPreference(TEST_PREFERENCE)
+            .build();
         model.setReservation(reservationInFilteredList, editedReservation);
+
         // Then show the preference
         PreferenceCommand preferenceCommand = new PreferenceCommand(INDEX_FIRST_RESERVATION, true);
 
         String expectedMessage = String.format(PreferenceCommand.MESSAGE_SHOW_PREFERENCE_SUCCESS,
-                INDEX_FIRST_RESERVATION.getOneBased(), TEST_PREFERENCE);
+            INDEX_FIRST_RESERVATION.getOneBased(), TEST_PREFERENCE);
 
         assertCommandSuccess(preferenceCommand, model, expectedMessage, model);
     }
 
     @Test
     public void execute_showEmptyPreference_returnsNoPreferenceMessage() {
-        // Ensure the reservation has no preference set (or has default "None")
+        // Ensure the reservation has no preference set
         Reservation reservationInFilteredList = model.getFilteredReservationList()
             .get(INDEX_FIRST_RESERVATION.getZeroBased());
-        if (!reservationInFilteredList.getPreference().isEmpty()) {
-            Reservation editedReservation = reservationInFilteredList.withPreference("");
-            model.setReservation(reservationInFilteredList, editedReservation);
-        }
+        Reservation editedReservation = new ReservationBuilder(reservationInFilteredList)
+            .withPreference("")
+            .build();
+        model.setReservation(reservationInFilteredList, editedReservation);
+
         PreferenceCommand preferenceCommand = new PreferenceCommand(INDEX_FIRST_RESERVATION, true);
         assertCommandSuccess(preferenceCommand, model, PreferenceCommand.MESSAGE_NO_PREFERENCE, model);
-    }
-
-    @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredReservationList().size() + 1);
-        PreferenceCommand saveCommand = new PreferenceCommand(outOfBoundIndex, TEST_PREFERENCE);
-        PreferenceCommand showCommand = new PreferenceCommand(outOfBoundIndex, true);
-
-        assertCommandFailure(saveCommand, model, Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
-        assertCommandFailure(showCommand, model, Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showReservationAtIndex(model, INDEX_FIRST_RESERVATION);
-        Index outOfBoundIndex = INDEX_SECOND_RESERVATION;
-        // ensures that outOfBoundIndex is still in bounds of reservation book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getReserveMate().getReservationList().size());
-
-        PreferenceCommand saveCommand = new PreferenceCommand(outOfBoundIndex, TEST_PREFERENCE);
-        PreferenceCommand showCommand = new PreferenceCommand(outOfBoundIndex, true);
-
-        assertCommandFailure(saveCommand, model, Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
-        assertCommandFailure(showCommand, model, Messages.MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void equals() {
-        final PreferenceCommand standardSaveCommand = new PreferenceCommand(INDEX_FIRST_RESERVATION, TEST_PREFERENCE);
-        final PreferenceCommand standardShowCommand = new PreferenceCommand(INDEX_FIRST_RESERVATION, true);
-
-        // same object -> returns true
-        assertTrue(standardSaveCommand.equals(standardSaveCommand));
-        assertTrue(standardShowCommand.equals(standardShowCommand));
-
-        // same values -> returns true
-        PreferenceCommand saveCommandCopy = new PreferenceCommand(INDEX_FIRST_RESERVATION, TEST_PREFERENCE);
-        PreferenceCommand showCommandCopy = new PreferenceCommand(INDEX_FIRST_RESERVATION, true);
-        assertTrue(standardSaveCommand.equals(saveCommandCopy));
-        assertTrue(standardShowCommand.equals(showCommandCopy));
-
-        // different index -> returns false
-        assertFalse(standardSaveCommand.equals(new PreferenceCommand(INDEX_SECOND_RESERVATION, TEST_PREFERENCE)));
-        assertFalse(standardShowCommand.equals(new PreferenceCommand(INDEX_SECOND_RESERVATION, true)));
-
-        // different preference -> returns false
-        assertFalse(standardSaveCommand.equals(new PreferenceCommand(INDEX_FIRST_RESERVATION, DIFFERENT_PREFERENCE)));
-
-        // save vs show -> returns false
-        assertFalse(standardSaveCommand.equals(standardShowCommand));
     }
 }

--- a/src/test/java/seedu/reserve/logic/parser/PreferenceCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/PreferenceCommandParserTest.java
@@ -11,9 +11,11 @@ import seedu.reserve.logic.commands.PreferenceCommand;
 
 public class PreferenceCommandParserTest {
 
-    private static final String VALID_PREFERENCE = "No nuts, allergic to seafood";
+    public static final String MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX =
+        "The reservation index provided is invalid";
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, PreferenceCommand.MESSAGE_USAGE);
+        String.format(MESSAGE_INVALID_COMMAND_FORMAT, PreferenceCommand.MESSAGE_USAGE);
+    private static final String VALID_PREFERENCE = "No nuts, allergic to seafood";
 
     private final PreferenceParser parser = new PreferenceParser();
 
@@ -44,16 +46,16 @@ public class PreferenceCommandParserTest {
     @Test
     public void parse_invalidIndex_failure() {
         // negative index
-        assertParseFailure(parser, "save -5 " + VALID_PREFERENCE, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "show -5", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "save -5 ", MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
+        assertParseFailure(parser, "show -5", MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
 
         // zero index
-        assertParseFailure(parser, "save 0 " + VALID_PREFERENCE, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "show 0", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "save 0 ", MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
+        assertParseFailure(parser, "show 0", MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
 
         // invalid characters in index
-        assertParseFailure(parser, "save abc " + VALID_PREFERENCE, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "show abc", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "save abc ", MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
+        assertParseFailure(parser, "show abc", MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/reserve/logic/parser/PreferenceCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/PreferenceCommandParserTest.java
@@ -15,7 +15,7 @@ public class PreferenceCommandParserTest {
         "The reservation index provided is invalid";
     private static final String MESSAGE_INVALID_FORMAT =
         String.format(MESSAGE_INVALID_COMMAND_FORMAT, PreferenceCommand.MESSAGE_USAGE);
-    private static final String VALID_PREFERENCE = "No nuts, allergic to seafood";
+    private static final String VALID_PREFERENCE = "No nuts and allergic to seafood";
 
     private final PreferenceParser parser = new PreferenceParser();
 
@@ -87,5 +87,18 @@ public class PreferenceCommandParserTest {
         }
         String userInput = "save 1 " + longPreference;
         assertParseFailure(parser, userInput, PreferenceParser.MESSAGE_PREFERENCE_TOO_LONG);
+    }
+
+    @Test
+    public void parse_invalidPreferenceCharacters_failure() {
+        // Test with special characters
+        assertParseFailure(parser, "save 1 Invalid!@#", PreferenceParser.MESSAGE_INVALID_PREFERENCE_CHARACTERS);
+
+        // Test with underscore
+        assertParseFailure(parser, "save 1 Invalid_Preference", PreferenceParser.MESSAGE_INVALID_PREFERENCE_CHARACTERS);
+
+        // Test with other symbols
+        assertParseFailure(parser, "save 1 Preference$", PreferenceParser.MESSAGE_INVALID_PREFERENCE_CHARACTERS);
+        assertParseFailure(parser, "save 1 Preference&Text", PreferenceParser.MESSAGE_INVALID_PREFERENCE_CHARACTERS);
     }
 }

--- a/src/test/java/seedu/reserve/model/reservation/ReservationPreferenceTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/ReservationPreferenceTest.java
@@ -17,28 +17,29 @@ public class ReservationPreferenceTest {
 
     @Test
     public void getPreference_defaultConstructor_returnsNone() {
-        Reservation reservation = new ReservationBuilder().build();
-        assertEquals("None", reservation.getPreference());
+        assertEquals("None", new ReservationBuilder().build().getPreference().toString());
     }
 
     @Test
     public void getPreference_customPreference_returnsCorrectPreference() {
-        Reservation reservation = new ReservationBuilder().withPreference(TEST_PREFERENCE).build();
-        assertEquals(TEST_PREFERENCE, reservation.getPreference());
+        assertEquals(TEST_PREFERENCE, new ReservationBuilder()
+            .withPreference(TEST_PREFERENCE).build().getPreference().toString());
     }
 
     @Test
     public void withPreference_nullPreference_throwsNullPointerException() {
-        Reservation reservation = new ReservationBuilder().build();
-        assertThrows(NullPointerException.class, () -> reservation.withPreference(null));
+        assertThrows(NullPointerException.class, () -> new ReservationBuilder()
+            .withPreference(null).build());
     }
 
     @Test
     public void withPreference_validPreference_returnsReservationWithUpdatedPreference() {
         Reservation originalReservation = new ReservationBuilder().build();
-        Reservation updatedReservation = originalReservation.withPreference(TEST_PREFERENCE);
+        Reservation updatedReservation = new ReservationBuilder(originalReservation)
+            .withPreference(TEST_PREFERENCE)
+            .build();
         // Check that the preference was updated
-        assertEquals(TEST_PREFERENCE, updatedReservation.getPreference());
+        assertEquals(TEST_PREFERENCE, updatedReservation.getPreference().toString());
         // Check that other fields remain the same
         assertEquals(originalReservation.getName(), updatedReservation.getName());
         assertEquals(originalReservation.getPhone(), updatedReservation.getPhone());

--- a/src/test/java/seedu/reserve/storage/JsonAdaptedReservationTest.java
+++ b/src/test/java/seedu/reserve/storage/JsonAdaptedReservationTest.java
@@ -17,6 +17,7 @@ import seedu.reserve.model.reservation.Diners;
 import seedu.reserve.model.reservation.Email;
 import seedu.reserve.model.reservation.Name;
 import seedu.reserve.model.reservation.Phone;
+import seedu.reserve.model.reservation.Preference;
 
 public class JsonAdaptedReservationTest {
     private static final String INVALID_NAME = "R@chel";
@@ -25,6 +26,9 @@ public class JsonAdaptedReservationTest {
     private static final String INVALID_OCCASION = "#friend";
     private static final String INVALID_DINERS = "0";
     private static final String INVALID_DATETIME = "2020-01-01 180";
+    private static final String INVALID_PREFERENCE = "LONGERTHANFIFTYCHARACTERS"
+        + "LONGERTHANFIFTYCHARACTERSLONGERTHANFIFTYCHARACTERSLONGERTHANFIFTYCHARACTERS"
+        + "LONGERTHANFIFTYCHARACTERSLONGERTHANFIFTYCHARACTERSLONGERTHANFIFTYCHARACTERS";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -34,6 +38,7 @@ public class JsonAdaptedReservationTest {
     private static final List<JsonAdaptedOccasion> VALID_OCCASIONS = BENSON.getOccasions().stream()
             .map(JsonAdaptedOccasion::new)
             .collect(Collectors.toList());
+    private static final String VALID_PREFERENCE = BENSON.getPreference().toString();
 
     @Test
     public void toModelType_validReservationDetails_returnsReservation() throws Exception {
@@ -45,7 +50,7 @@ public class JsonAdaptedReservationTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedReservation reservation =
                 new JsonAdaptedReservation(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_DINERS,
-                        VALID_DATETIME, VALID_OCCASIONS);
+                        VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -53,7 +58,7 @@ public class JsonAdaptedReservationTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedReservation reservation = new JsonAdaptedReservation(null, VALID_PHONE, VALID_EMAIL,
-                VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS);
+                VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -62,7 +67,7 @@ public class JsonAdaptedReservationTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedReservation reservation =
                 new JsonAdaptedReservation(VALID_NAME, INVALID_PHONE, VALID_EMAIL,
-                        VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS);
+                        VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -70,7 +75,7 @@ public class JsonAdaptedReservationTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedReservation reservation = new JsonAdaptedReservation(VALID_NAME, null, VALID_EMAIL,
-                VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS);
+                VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -79,7 +84,7 @@ public class JsonAdaptedReservationTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedReservation reservation =
                 new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, INVALID_EMAIL,
-                        VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS);
+                        VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -87,7 +92,7 @@ public class JsonAdaptedReservationTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedReservation reservation = new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, null,
-                VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS);
+                VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -96,7 +101,7 @@ public class JsonAdaptedReservationTest {
     public void toModelType_invalidDiners_throwsIllegalValueException() {
         JsonAdaptedReservation reservation =
                 new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        INVALID_DINERS, VALID_DATETIME, VALID_OCCASIONS);
+                        INVALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = Diners.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -104,7 +109,7 @@ public class JsonAdaptedReservationTest {
     @Test
     public void toModelType_nullDiners_throwsIllegalValueException() {
         JsonAdaptedReservation reservation = new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                null, VALID_DATETIME, VALID_OCCASIONS);
+                null, VALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Diners.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -113,7 +118,7 @@ public class JsonAdaptedReservationTest {
     public void toModelType_invalidDateTime_throwsIllegalValueException() {
         JsonAdaptedReservation reservation =
                 new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_DINERS, INVALID_DATETIME, VALID_OCCASIONS);
+                        VALID_DINERS, INVALID_DATETIME, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -121,7 +126,7 @@ public class JsonAdaptedReservationTest {
     @Test
     public void toModelType_nullDateTime_throwsIllegalValueException() {
         JsonAdaptedReservation reservation = new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_DINERS, null, VALID_OCCASIONS);
+                VALID_DINERS, null, VALID_OCCASIONS, VALID_PREFERENCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, DateTime.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
     }
@@ -132,8 +137,24 @@ public class JsonAdaptedReservationTest {
         invalidOccasions.add(new JsonAdaptedOccasion(INVALID_OCCASION));
         JsonAdaptedReservation reservation =
                 new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_DINERS, VALID_DATETIME, invalidOccasions);
+                        VALID_DINERS, VALID_DATETIME, invalidOccasions, VALID_PREFERENCE);
         assertThrows(IllegalValueException.class, reservation::toModelType);
     }
 
+    @Test
+    public void toModelType_invalidPreference_throwsIllegalValueException() {
+        JsonAdaptedReservation reservation =
+            new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_DINERS,
+                VALID_DATETIME, VALID_OCCASIONS, INVALID_PREFERENCE);
+        String expectedMessage = Preference.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullPreference_throwsIllegalValueException() {
+        JsonAdaptedReservation reservation = new JsonAdaptedReservation(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+            VALID_DINERS, VALID_DATETIME, VALID_OCCASIONS, null);
+        String expectedMessage = Preference.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, reservation::toModelType);
+    }
 }

--- a/src/test/java/seedu/reserve/testutil/ReservationBuilder.java
+++ b/src/test/java/seedu/reserve/testutil/ReservationBuilder.java
@@ -12,6 +12,7 @@ import seedu.reserve.model.reservation.Diners;
 import seedu.reserve.model.reservation.Email;
 import seedu.reserve.model.reservation.Name;
 import seedu.reserve.model.reservation.Phone;
+import seedu.reserve.model.reservation.Preference;
 import seedu.reserve.model.reservation.Reservation;
 import seedu.reserve.model.util.SampleDataUtil;
 
@@ -36,7 +37,7 @@ public class ReservationBuilder {
     private Diners diners;
     private DateTime dateTime;
     private Set<Occasion> occasions;
-    private String preference;
+    private Preference preference;
 
     /**
      * Creates a {@code ReservationBuilder} with the default details.
@@ -48,7 +49,7 @@ public class ReservationBuilder {
         diners = new Diners(DEFAULT_DINERS);
         dateTime = new DateTime(DEFAULT_DATETIME);
         occasions = new HashSet<>();
-        preference = DEFAULT_PREFERENCE;
+        preference = new Preference(DEFAULT_PREFERENCE);
     }
 
     /**
@@ -117,7 +118,7 @@ public class ReservationBuilder {
      * Sets the {@code Preference} of the {@code Reservation} that we are building.
      */
     public ReservationBuilder withPreference(String preference) {
-        this.preference = preference;
+        this.preference = new Preference(preference);
         return this;
     }
 

--- a/src/test/java/seedu/reserve/testutil/TypicalReservation.java
+++ b/src/test/java/seedu/reserve/testutil/TypicalReservation.java
@@ -31,6 +31,7 @@ public class TypicalReservation {
             .withDiners("5")
             .withDateTime("2025-04-10 1800")
             .withOccasions("friends")
+            .withPreference("No seafood")
             .build();
 
     public static final Reservation BENSON = new ReservationBuilder().withName("Benson Meier")
@@ -39,6 +40,7 @@ public class TypicalReservation {
             .withDiners("3")
             .withDateTime("2025-04-25 1200")
             .withOccasions("owesMoney", "friends")
+            .withPreference("Extra spicy")
             .build();
 
     public static final Reservation CARL = new ReservationBuilder().withName("Carl Kurz")
@@ -47,6 +49,7 @@ public class TypicalReservation {
             .withDiners("2")
             .withDateTime("2025-04-15 1400")
             .withOccasions("Birthday")
+            .withPreference("No nuts")
             .build();
 
     public static final Reservation DANIEL = new ReservationBuilder().withName("Daniel Meier")
@@ -55,6 +58,7 @@ public class TypicalReservation {
             .withDiners("4")
             .withDateTime("2025-04-20 1600")
             .withOccasions("friends")
+            .withPreference("Likes window seats")
             .build();
 
     public static final Reservation ELLE = new ReservationBuilder().withName("Elle Meyer")
@@ -63,6 +67,7 @@ public class TypicalReservation {
             .withDiners("1")
             .withDateTime("2025-04-05 1000")
             .withOccasions("Birthday")
+            .withPreference("Less salty")
             .build();
 
     public static final Reservation FIONA = new ReservationBuilder().withName("Fiona Kunz")
@@ -71,6 +76,7 @@ public class TypicalReservation {
             .withDiners("7")
             .withDateTime("2025-04-12 1100")
             .withOccasions("Birthday")
+            .withPreference("None")
             .build();
 
     public static final Reservation GEORGE = new ReservationBuilder().withName("George Best")
@@ -79,6 +85,7 @@ public class TypicalReservation {
             .withDiners("10")
             .withDateTime("2025-04-18 1300")
             .withOccasions("Anniversary")
+            .withPreference("More sugar")
             .build();
 
     public static final Reservation HOON = new ReservationBuilder().withName("Hoon Meier")
@@ -87,6 +94,7 @@ public class TypicalReservation {
             .withDiners("6")
             .withDateTime("2025-04-07 0900")
             .withOccasions("Birthday")
+            .withPreference("None")
             .build();
 
     public static final Reservation IDA = new ReservationBuilder().withName("Ida Mueller")
@@ -95,6 +103,7 @@ public class TypicalReservation {
             .withDiners("8")
             .withDateTime("2025-04-08 1700")
             .withOccasions("Birthday")
+            .withPreference("None")
             .build();
 
     // Manually added - Reservation's details found in {@code CommandTestUtil}


### PR DESCRIPTION
This PR fixes #169 and will now be able to save preference data into reservemate.json

Other minor fixes include:
1. Fixes #175 - Preference now only accepts spaces & alphanumeric  characters
2. Fixes #168, Fixes #193 - Preference error messages are now consistent

Updated JSON:
`{
  "reservations" : [ {
    "name" : "John Doe",
    "phone" : "98765432",
    "email" : "johnd@example.com",
    "diners" : "5",
    "dateTime" : "2025-04-13 1800",
    "occasions" : [ "Anniversary" ],
    "preference" : "No seafood"
  }, {
    "name" : "Alexa Yeoh",
    "phone" : "98765432",
    "email" : "alexy@example.com",
    "diners" : "5",
    "dateTime" : "2025-04-15 1300",
    "occasions" : [ "Birthday" ],
    "preference" : "Likes spicy"
  }, {
    "name" : "Minennene Mouse",
    "phone" : "98765432",
    "email" : "mickey@example.com",
    "diners" : "5",
    "dateTime" : "2025-04-22 1400",
    "occasions" : [ "Graduation Party " ],
    "preference" : "None"
  }, {
    "name" : "Barbie",
    "phone" : "98889888",
    "email" : "barbie@gmail.com",
    "diners" : "2",
    "dateTime" : "2025-08-30 1100",
    "occasions" : [ "Christmas" ],
    "preference" : "Less salt"
  } ]
}`