### PR TITLE
Invalid date filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ find Bobby
 Find Bobby
 ```
 
+### Feature: Filtering reservation between dates
+**Purpose:** View reservations between 2 dates more easily
+
+**Command format:** `filter sd/<DATETIME> ed/<DATETIME>`
+
+**Example commands:**
+```
+filter sd/2025-04-01 1400 ed/2025-04-02 1800
+Filter sd/2025-04-01 1400 ed/2025-04-02 1800
+```
+
 ### Feature: View all free time slots
 **Purpose:** View all free time slots for reservation within a window of 60days from current time.
 
@@ -155,20 +166,21 @@ Exit
 ```
 
 ## Command Summary
-| Feature                     | Command Format                                                                               | Purpose                                                                               |
-|-----------------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| Create a new reservation    | `add n/<NAME> p/<PHONE> e/<EMAIL> x/<NUMBER_OF_DINERS> d/<DATETIME> [o/OCCASION]…​`          | Add new reservation to ReserveMate                                                    |
+| Feature                     | Command Format                                                                              | Purpose                                                                               |
+|-----------------------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| Create a new reservation    | `add n/<NAME> p/<PHONE> e/<EMAIL> x/<NUMBER_OF_DINERS> d/<DATETIME> [o/OCCASION]…​`         | Add new reservation to ReserveMate                                                    |
 | Editing a reservation       | `edit <INDEX> [n/NAME] [p/PHONE] [e/EMAIL] [x/NUMBER_OF_DINERS] [d/DATETIME] [o/OCCASION]…​` | Edit existing details of a reservation                                                |
-| Delete reservation          | `delete <INDEX>`                                                                             | Remove a reservation from ReserveMate                                                 |
-| Show Reservation details    | `show <INDEX>`                                                                               | Show details of reservation to user                                                   |
-| View all free time slots    | `free`                                                                                       | View all free time slots for reservation within a window of 60days from current time. |
-| View reservation list       | `list`                                                                                       | View the entire reservation schedule                                                  |
-| View help list              | `help`                                                                                       | Display the available list of commands to the user                                    |
-| Find reservation by name    | `find <RESERVATION NAME>`                                                                    | Retrieve reservation information                                                      |
-| Manage preferences          | `pref save <INDEX> <PREFERENCE_TEXT>` or `pref show <INDEX>`                                 | Save or display reservation preferences                                               |
-| Clearing all reservations   | `clear`                                                                                      | Deletes all reservations in ReserveMate                                               |
-| View reservation statistics | `stats`                                                                                      | Display reservation statistics of ReserveMate                                         |
-| Exiting the application     | `exit`                                                                                       | Terminates the application                                                            |
+| Delete reservation          | `delete <INDEX>`                                                                            | Remove a reservation from ReserveMate                                                 |
+| Show Reservation details    | `show <INDEX>`                                                                              | Show details of reservation to user                                                   |
+| View all free time slots    | `free`                                                                                      | View all free time slots for reservation within a window of 60days from current time. |
+| View reservation list       | `list`                                                                                      | View the entire reservation schedule                                                  |
+| View help list              | `help`                                                                                      | Display the available list of commands to the user                                    |
+| Find reservation by name    | `find <RESERVATION NAME>`                                                                   | Retrieve reservation information                                                      |
+| Manage preferences          | `pref save <INDEX> <PREFERENCE_TEXT>` or `pref show <INDEX>`                                | Save or display reservation preferences                                               |
+| Clearing all reservations   | `clear`                                                                                     | Deletes all reservations in ReserveMate                                               |
+| View reservation statistics | `stats`                                                                                     | Display reservation statistics of ReserveMate                                         |
+| Filter reservations by date | `filter sd/<DATETIME> ed/<DATETIME>`                                                        | Display reservations between given dates                                              |
+| Exiting the application     | `exit`                                                                                      | Terminates the application                                                            |
 
 ### Acknowledgement
 This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -136,8 +136,9 @@ The prefixes used in ReserveMate are universal across all commands.
 
 - 2 to 50 characters inclusive.
 
+- Names should contain only characters and spaces
+
 - Names can be:
-    - Entirely numeric (e.g., `n/123456`) — though discouraged due to confusion with indexes.
     - A **single character or initial** (e.g., `n/A`) — valid but potentially confusing in lists.
 
 ---
@@ -947,7 +948,7 @@ Format: `filter sd/ DATE_TIME ed/ DATE_TIME`
 
 **Constraints**
 - Filters all reservations between the given `DATE_TIME`, inclusive of the `DATE_TIME` provided.
--`DATE_TIME` provided must be valid (within 60 days) and follow the format: `YYYY-MM-DD HHmm`.
+-`DATE_TIME` provided must be valid and follow the format: `YYYY-MM-DD HHmm`.
 - The `DATE_TIME` provided for `sd/` must be before the date and time provided for `ed/`
 
 ---

--- a/src/main/java/seedu/reserve/model/reservation/DateTime.java
+++ b/src/main/java/seedu/reserve/model/reservation/DateTime.java
@@ -6,6 +6,7 @@ import static seedu.reserve.commons.util.AppUtil.checkArgument;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
 
 import seedu.reserve.logic.parser.exceptions.ParseException;
@@ -21,9 +22,11 @@ public class DateTime implements Comparable<DateTime> {
             + "1. The date must be a valid calendar date. \n"
             + "2. The time must be in hourly increments (e.g., 0000, 0100, etc.). \n"
             + "3. The date-time must be after the current time but within 60 days from now.";
-    public static final String MESSAGE_CONSTRAINTS_FILTER = "DateTime must be in the format YYYY-MM-DD HHmm";
+    public static final String MESSAGE_CONSTRAINTS_FILTER = "DateTime must be in the format YYYY-MM-DD HHmm and " +
+            "must be a valid calendar date. \n";
     public static final String VALIDATION_REGEX = "^\\d{4}-\\d{2}-\\d{2} \\d{4}$";
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HHmm")
+            .withResolverStyle(ResolverStyle.STRICT);
     private static final LocalDateTime currentDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS);
 
     public final LocalDateTime value;

--- a/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.testutil.Assert.assertThrows;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -17,6 +18,7 @@ public class DateTimeTest {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
     private static final String INVALID_DATE_TIME_FORMAT_STR = "2025-12-12 180";
+    private static final String INVALID_DATE_TIME = "2025-02-29 1800";
     private static final DateTime endDate = DateTime.fromFileString("2025-12-15 1800");
     private static final DateTime middleDate = DateTime.fromFileString("2025-12-13 1400");
     private static final DateTime outOfBoundsDate = DateTime.fromFileString("2025-12-16 1800");
@@ -85,6 +87,14 @@ public class DateTimeTest {
     }
 
     @Test
+    public void isInvalidDateTime() {
+        assertFalse(DateTime.isValidDateTime(INVALID_DATE_TIME));
+
+        assertThrows(IllegalArgumentException.class, () -> new DateTime(INVALID_DATE_TIME));
+        assertThrows(DateTimeException.class, () -> DateTime.fromFileString(INVALID_DATE_TIME));
+    }
+
+    @Test
     public void isValidFileInputDateTime() {
         // invalid date time
         assertFalse(DateTime.isValidFileInputDateTime(""));
@@ -93,6 +103,7 @@ public class DateTimeTest {
         // valid date time
         assertTrue(DateTime.isValidFileInputDateTime(formattedYesterdayDateTime));
         assertTrue(DateTime.isValidFileInputDateTime(formattedTomorrowDateTime));
+        assertEquals(DateTime.class, DateTime.fromFileString(formattedYesterdayDateTime).getClass());
 
     }
 


### PR DESCRIPTION
Fixes  #177 #178

Changes made:
 - Stricter parsing of datetime, invalid dates like `2025-02-30 1400` are not allowed
 - Update user guides  