### PR TITLE
Fix occasion

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -107,7 +107,7 @@ The prefixes used in ReserveMate are universal across all commands.
 | `d/`   | Reservation Date & Time | Format: `YYYY-MM-DD HHmm`. Must be within next 60 days.                                                                                                                                                                                                                                                                                                                  | `d/2025-05-11 1800`, `d/2025-04-30 1000`   | `d/2023-02-21`, `d/2028-02-21 0900`, `d/past` |
 | `sd/`  | Start Date (Filter)     | Format: `YYYY-MM-DD HHmm`. Must be earlier than `ed/`.                                                                                                                                                                                                                                                                                                                   | `sd/2025-05-01 1800`                       | `sd/2025-13-01`, `sd/invalid`, `sd/`          |
 | `ed/`  | End Date (Filter)       | Format: `YYYY-MM-DD HHmm`. Must be later than `sd/`.                                                                                                                                                                                                                                                                                                                     | `ed/2025-05-15 2200`                       | `ed/2025-01-01`, `ed/late`, `ed/`             |
-| `o/`   | Occasion                | 2–50 characters, only `Alphanumeric` and is `variadic`. Optional??                                                                                                                                                                                                                                                                                                       | `o/Birthday`, `o/Anniversary o/VIP`        | `o/`, `o/@celebration`                        |
+| `o/`   | Occasion                | 2–50 characters, only `Alphanumeric` and is `variadic`. It is optional.                                                                                                                                                                                                                                                                                                  | `o/Birthday`, `o/Anniversary o/VIP`        | `o/`, `o/@celebration`                        |
 
 **Notes:**
 
@@ -180,7 +180,8 @@ The prefixes used in ReserveMate are universal across all commands.
 
 - Prefix is **optional and variadic** (can appear multiple times).
 - Accepts alphanumeric values and basic punctuation.
-- Blank values (e.g., `o/`) will clear the occasions for the specific reservation.
+- Blank values (e.g., `o/`) will clear the occasions for the specific reservation when used in `edit` command it will
+result in an error when used in `add` command
 - No enforcement of case — `o/birthday` and `o/Birthday` are treated the same.
 
 ---
@@ -341,7 +342,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [d/DATE_TIME] [x/NUMBER_OF_DINE
 **Constraints**
 * `INDEX` **must be a positive integer** referring to a valid reservation in the list.
 * At least one of field (prefix) must be provided.
-* Editing occasion replaces the full list of occasions. Use `o/` with no value to clear.
+* Editing occasion replaces the existing list of occasions. Use `o/` with no value to clear.
 * Dates must be within 60 days from now and in the future.
 
 - **Successful Execution:**

--- a/src/main/java/seedu/reserve/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/AddCommand.java
@@ -37,10 +37,6 @@ public class AddCommand extends Command {
             + PREFIX_DATE_TIME + "2025-04-28 1800 "
             + PREFIX_OCCASION + "Birthday ";
     public static final String MESSAGE_SUCCESS = "New reservation added:\n%1$s";
-    public static final String MESSAGE_OCCASION_CONSTRAINTS = "Please indicate an occasion: \n"
-        + "Example: " + PREFIX_OCCASION + "Birthday \n"
-        + "Example: " + PREFIX_OCCASION + "None \n"
-        + "Occasion name must not be empty and must be alphanumeric";
 
     private final Reservation toAdd;
 
@@ -58,10 +54,6 @@ public class AddCommand extends Command {
 
         if (model.hasReservation(toAdd)) {
             throw new CommandException(Messages.MESSAGE_DUPLICATE_RESERVATION);
-        }
-
-        if (toAdd.getOccasions().isEmpty()) {
-            throw new CommandException(MESSAGE_OCCASION_CONSTRAINTS);
         }
 
         model.addReservation(toAdd);

--- a/src/main/java/seedu/reserve/model/occasion/Occasion.java
+++ b/src/main/java/seedu/reserve/model/occasion/Occasion.java
@@ -33,7 +33,7 @@ public class Occasion {
      * Returns true if a given string is a valid occasion name.
      */
     public static boolean isValidOccasionName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && (test.length() >= 2 && test.length() <= 50);
     }
 
     @Override

--- a/src/test/java/seedu/reserve/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/AddCommandTest.java
@@ -56,14 +56,15 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_missingOccasion_throwsCommandException() {
+    public void execute_missingOccasion_success() throws CommandException {
         ModelStubAcceptingReservationAdded modelStub = new ModelStubAcceptingReservationAdded();
-        Reservation reservationWithoutOccasion = new ReservationBuilder().withOccasions().build(); // No occasion
+        Reservation validReservation = new ReservationBuilder().withOccasions().build(); // No occasion
 
-        AddCommand addCommand = new AddCommand(reservationWithoutOccasion);
+        CommandResult addCommandResult = new AddCommand(validReservation).execute(modelStub);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_OCCASION_CONSTRAINTS, ()
-            -> addCommand.execute(modelStub));
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validReservation)),
+                addCommandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validReservation), modelStub.reservationsAdded);
     }
 
     @Test

--- a/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
@@ -28,6 +28,8 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_OCCASION = "#gambling";
+    private static final String INVALID_OCCASION_LONG = "long word".repeat(50);
+    private static final String INVALID_OCCASION_SHORT = "a";
     private static final String INVALID_DINERS = "0";
     private static final String INVALID_DATETIME = "2030-04-12 180";
     private static final String INVALID_FILTER_DATETIME = "2025-13-01 1900";
@@ -212,6 +214,8 @@ public class ParserUtilTest {
     @Test
     public void parseOccasion_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseOccasion(INVALID_OCCASION));
+        assertThrows(ParseException.class, () -> ParserUtil.parseOccasion(INVALID_OCCASION_LONG));
+        assertThrows(ParseException.class, () -> ParserUtil.parseOccasion(INVALID_OCCASION_SHORT));
     }
 
     @Test
@@ -228,14 +232,11 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseOccasions_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseOccasions(null));
-    }
-
-    @Test
     public void parseOccasions_collectionWithInvalidOccasions_throwsParseException() {
         assertThrows(ParseException.class, () ->
             ParserUtil.parseOccasions(Arrays.asList(VALID_OCCASION_1, INVALID_OCCASION)));
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseOccasions(Arrays.asList(VALID_OCCASION_1, INVALID_OCCASION_LONG)));
     }
 
     @Test


### PR DESCRIPTION
Changes Made:
- 'o/` tag is now optional to implement
- The min length of occasion tag is 2 and the max length is 50

Behavior: (stated in the userguide)
- `add n/john p/90089008 e/jhon@gmail.com d/2025-04-04 1400 x/5` -> success
- `add n/john p/90089008 e/jhon@gmail.com d/2025-04-04 1400 x/5 o/` -> error as occasion name cannot be empty
- `edit 1 o/` -> clears reservations 

Fixes #173 
Fixes #174 
Fixes #176