### PR TITLE
Fix find bugs

### DIFF
--- a/src/main/java/seedu/reserve/logic/Messages.java
+++ b/src/main/java/seedu/reserve/logic/Messages.java
@@ -23,7 +23,7 @@ public class Messages {
     public static final String MESSAGE_EMPTY_RESERVATION_LIST =
             "No reservations found. Use the 'add' command to create a reservation\n"
                     + "or 'help' to view all commands.";
-    public static final String MESSAGE_NO_RESERVATIONS = "No reservations found.";
+    public static final String MESSAGE_NO_RESERVATIONS = "No reservations found. Try using the full name. For example, use 'John' instead of just 'Jo'.";
     public static final String MESSAGE_DUPLICATE_RESERVATION =
             "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
 

--- a/src/main/java/seedu/reserve/logic/Messages.java
+++ b/src/main/java/seedu/reserve/logic/Messages.java
@@ -23,7 +23,8 @@ public class Messages {
     public static final String MESSAGE_EMPTY_RESERVATION_LIST =
             "No reservations found. Use the 'add' command to create a reservation\n"
                     + "or 'help' to view all commands.";
-    public static final String MESSAGE_NO_RESERVATIONS = "No reservations found. Try using the full name. For example, use 'John' instead of just 'Jo'.";
+    public static final String MESSAGE_NO_RESERVATIONS = "No reservations found. Try using the full name. "
+            + "For example, use 'John' instead of just 'Jo'.";
     public static final String MESSAGE_DUPLICATE_RESERVATION =
             "A reservation already exists for this customer (same email or phone) at the chosen date-time.";
 

--- a/src/main/java/seedu/reserve/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/FindCommandParser.java
@@ -39,13 +39,9 @@ public class FindCommandParser implements Parser<FindCommand> {
 
             if (!trimmedKeyword.matches("[A-Za-z]+")) {
                 throw new ParseException(MESSAGE_INVALID_NAME);
-            }
-
-            else if (trimmedKeyword.length() < 2) {
+            } else if (trimmedKeyword.length() < 2) {
                 throw new ParseException(MESSAGE_SHORT_NAME);
-            }
-
-            else if (trimmedKeyword.length() > 50) {
+            } else if (trimmedKeyword.length() > 50) {
                 throw new ParseException(MESSAGE_LONG_NAME);
             }
 

--- a/src/main/java/seedu/reserve/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/FindCommandParser.java
@@ -14,8 +14,7 @@ import seedu.reserve.model.reservation.NameContainsKeywordsPredicate;
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
-    public static final String MESSAGE_INVALID_NAME = "Invalid name format. Only alphabets, "
-            + "hyphens(-) and apostrophes(') are allowed.";
+    public static final String MESSAGE_INVALID_NAME = "Invalid name format. Name should contain only letters.";
     public static final String MESSAGE_SHORT_NAME = "Invalid name. The name must have at least 2 characters.";
     public static final String MESSAGE_LONG_NAME = "Invalid name. The name must be 50 characters or less.";
 
@@ -38,19 +37,23 @@ public class FindCommandParser implements Parser<FindCommand> {
         for (String keyword : nameKeywords) {
             String trimmedKeyword = keyword.trim();
 
-            if (trimmedKeyword.length() < 2) {
-                throw new ParseException(MESSAGE_SHORT_NAME);
-            }
-
-            if (trimmedKeyword.length() > 50) {
-                throw new ParseException(MESSAGE_LONG_NAME);
-            }
-
-            if (!trimmedKeyword.matches("[A-Za-z' -]+")) {
+            if (!trimmedKeyword.matches("[A-Za-z]+")) {
                 throw new ParseException(MESSAGE_INVALID_NAME);
             }
 
+            else if (trimmedKeyword.length() < 2) {
+                throw new ParseException(MESSAGE_SHORT_NAME);
+            }
+
+            else if (trimmedKeyword.length() > 50) {
+                throw new ParseException(MESSAGE_LONG_NAME);
+            }
+
             validKeywords.add(trimmedKeyword.toLowerCase());
+        }
+
+        if (validKeywords.isEmpty()) {
+            throw new ParseException(MESSAGE_INVALID_NAME);
         }
 
         return new FindCommand(new NameContainsKeywordsPredicate(validKeywords));

--- a/src/main/java/seedu/reserve/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/FindCommandParser.java
@@ -48,10 +48,6 @@ public class FindCommandParser implements Parser<FindCommand> {
             validKeywords.add(trimmedKeyword.toLowerCase());
         }
 
-        if (validKeywords.isEmpty()) {
-            throw new ParseException(MESSAGE_INVALID_NAME);
-        }
-
         return new FindCommand(new NameContainsKeywordsPredicate(validKeywords));
     }
 

--- a/src/test/java/seedu/reserve/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/FindCommandParserTest.java
@@ -93,4 +93,6 @@ public class FindCommandParserTest {
         assertParseFailure(parser, "Anne-Marie", MESSAGE_INVALID_NAME);
         assertParseFailure(parser, "O'Connor", MESSAGE_INVALID_NAME);
     }
+
+
 }

--- a/src/test/java/seedu/reserve/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/FindCommandParserTest.java
@@ -20,7 +20,8 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -38,21 +39,58 @@ public class FindCommandParserTest {
     public void parse_shortArgs_throwsParseException() {
         // name length < 2
         String userInput = "a";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_SHORT_NAME, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput, MESSAGE_SHORT_NAME);
     }
 
     @Test
     public void parse_longArgs_throwsParseException() {
         // name length > 50
         String userInput = "sadhsfajnkfbsghdorewjkjrfkshguriewoklmsdlnfbgkjshrekwmdanfsbgrekalndfjsbghirjknjgd";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_LONG_NAME, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput, MESSAGE_LONG_NAME);
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         // name contains numbers or special symbols
         String userInput = "p0tAt0";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_NAME, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_NAME);
     }
 
+    @Test
+    public void parse_multipleShortNames_throwsParseException() {
+        String userInput = "a b";
+        assertParseFailure(parser, userInput, MESSAGE_SHORT_NAME);
+    }
+
+    @Test
+    public void parse_mixedValidAndInvalidNames_throwsParseException() {
+        String userInput = "alice 123";
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_NAME);
+    }
+
+    @Test
+    public void parse_nameWithSpecialCharacters_throwsParseException() {
+        assertParseFailure(parser, "john!", MESSAGE_INVALID_NAME);
+        assertParseFailure(parser, "al!ce", MESSAGE_INVALID_NAME);
+        assertParseFailure(parser, "jo@hn", MESSAGE_INVALID_NAME);
+    }
+
+    @Test
+    public void parse_emptyKeywordBetweenSpaces_throwsParseException() {
+        String userInput = "john  ";
+        FindCommand expected = new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("john")));
+        assertParseSuccess(parser, userInput, expected);
+    }
+
+    @Test
+    public void parse_caseInsensitivity_returnsLowercasedKeywords() {
+        FindCommand expected = new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("alice", "bob")));
+        assertParseSuccess(parser, "ALICE BoB", expected);
+    }
+
+    @Test
+    public void parse_nameWithHyphenOrApostrophe_throwsParseException() {
+        assertParseFailure(parser, "Anne-Marie", MESSAGE_INVALID_NAME);
+        assertParseFailure(parser, "O'Connor", MESSAGE_INVALID_NAME);
+    }
 }


### PR DESCRIPTION
Fix #164 , #192 , #207 , #208 , #218.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/e7db7524-39db-4f94-86dc-70bb3fdcda76" />

When no reservations are found, a warning message is given so users are aware that full name needs to be used to find reservations.

<img width="724" alt="image" src="https://github.com/user-attachments/assets/61354564-9510-4502-b496-f5aaa5e6ba84" />

Input names for find command only allows characters of length 2 to 50. Name is case-insensitive