### PR TITLE
Remove restriction to remove past reservation

### DIFF
--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -98,9 +98,10 @@ public class EditCommand extends Command {
 
         Reservation reservationToEdit = lastShownList.get(index.getZeroBased());
         Reservation editedReservation = createEditedReservation(reservationToEdit, editReservationDescriptor);
-
+        String out = "";
         if (isDateTimeBeforeCurrentTime(reservationToEdit.getDateTime())) {
-            throw new CommandException(MESSAGE_FUTURE_RESERVATION_REQUIRED);
+//            throw new CommandException(MESSAGE_FUTURE_RESERVATION_REQUIRED);
+            out = "Warning, you had edited a past reservation!!!\n";
         }
 
         if (!reservationToEdit.isSameReservation(editedReservation) && model.hasReservation(editedReservation)) {
@@ -110,7 +111,7 @@ public class EditCommand extends Command {
 
         model.setReservation(reservationToEdit, editedReservation);
         model.updateFilteredReservationList(PREDICATE_SHOW_ALL_RESERVATIONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_RESERVATION_SUCCESS, Messages.format(editedReservation)));
+        return new CommandResult(out + String.format(MESSAGE_EDIT_RESERVATION_SUCCESS, Messages.format(editedReservation)));
     }
 
     /**

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -101,7 +101,7 @@ public class EditCommand extends Command {
         String out = "";
         if (isDateTimeBeforeCurrentTime(reservationToEdit.getDateTime())) {
 //            throw new CommandException(MESSAGE_FUTURE_RESERVATION_REQUIRED);
-            out = "Warning, you had edited a past reservation!!!\n";
+            out = "Warning: You modified a past reservation!\n";
         }
 
         if (!reservationToEdit.isSameReservation(editedReservation) && model.hasReservation(editedReservation)) {

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -107,9 +107,7 @@ public class EditCommand extends Command {
         }
         if (!reservationToEdit.isSameReservation(editedReservation) && model.hasReservation(editedReservation)) {
             throw new CommandException(Messages.MESSAGE_DUPLICATE_RESERVATION);
-
         }
-
         model.setReservation(reservationToEdit, editedReservation);
         model.updateFilteredReservationList(PREDICATE_SHOW_ALL_RESERVATIONS);
         return new CommandResult(out + String.format(MESSAGE_EDIT_RESERVATION_SUCCESS,

--- a/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
@@ -21,6 +21,7 @@ import seedu.reserve.logic.commands.EditCommand;
 import seedu.reserve.logic.parser.exceptions.ParseException;
 import seedu.reserve.model.occasion.Occasion;
 
+
 /**
  * Parses input arguments and creates a new EditCommand object
  */
@@ -73,7 +74,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_DATE_TIME).isPresent()) {
             editReservationDescriptor
-                    .setDateTime(ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE_TIME).get()));
+                    .setDateTime(ParserUtil.parseEditedDateTime(argMultimap.getValue(PREFIX_DATE_TIME).get()));
         }
         parseOccasionsForEdit(argMultimap.getAllValues(PREFIX_OCCASION))
             .ifPresent(editReservationDescriptor::setOccasions);

--- a/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
@@ -177,6 +177,19 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String dateTime} into a {@code DateTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code dateTime} is invalid.
+     */
+    public static DateTime parseEditedDateTime(String editedDateTime) throws ParseException {
+        requireNonNull(editedDateTime);
+        String trimmedEditDateTime = editedDateTime.trim();
+        return DateTime.fromFileString(trimmedEditDateTime);
+    }
+
+
+    /**
      * Parses a {@code dateTimeFile} to a {@code  DateTime}. Does not check if {@code dateTimeFile}
      * is after today's date.
      *

--- a/src/main/java/seedu/reserve/model/reservation/DateTime.java
+++ b/src/main/java/seedu/reserve/model/reservation/DateTime.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 
+import seedu.reserve.logic.commands.EditCommand;
+import seedu.reserve.logic.commands.exceptions.CommandException;
 import seedu.reserve.logic.parser.exceptions.ParseException;
 
 /**
@@ -69,6 +71,41 @@ public class DateTime implements Comparable<DateTime> {
 
             LocalDateTime parsedDateTime = LocalDateTime.parse(test, FORMATTER);
             return isAfterCurrentTime(parsedDateTime) && isBeforeMaxBookingTime(parsedDateTime);
+        } catch (DateTimeParseException | ParseException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if a given string is a valid date-time for editing.
+     * If the date is in the past, return false.
+     * Otherwise, return true.
+     */
+    public static boolean isValidEditedDateTime(DateTime editedDateTime, DateTime toEditDateTime)
+            throws CommandException {
+        try {
+            String toEditDateTimeStr = toEditDateTime.value.format(FORMATTER);
+            String editedDateTimeStr = editedDateTime.value.format(FORMATTER);
+
+            LocalDateTime toEditTimeParser = LocalDateTime.parse(toEditDateTimeStr, FORMATTER);
+            LocalDateTime editedDateTimeParser = LocalDateTime.parse(editedDateTimeStr, FORMATTER);
+
+
+            // If the date is before the current time return false
+            if (!isAfterCurrentTime(toEditTimeParser)) {
+                if (!editedDateTime.equals(toEditDateTime)) {
+                    throw new CommandException(EditCommand.MESSAGE_UNABLE_TO_EDIT_PAST_RESERVATION);
+                }
+                return true;
+            }
+            if (!isAfterCurrentTime(editedDateTimeParser)) {
+                return false;
+            }
+            if (!isHourlyTiming(editedDateTimeStr)) {
+                return false;
+            }
+            // Check the time constraint
+            return isBeforeMaxBookingTime(editedDateTimeParser);
         } catch (DateTimeParseException | ParseException e) {
             return false;
         }

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -3,6 +3,7 @@ package seedu.reserve.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_BOB;
@@ -36,6 +37,7 @@ import seedu.reserve.model.Model;
 import seedu.reserve.model.ModelManager;
 import seedu.reserve.model.ReserveMate;
 import seedu.reserve.model.UserPrefs;
+import seedu.reserve.model.reservation.DateTime;
 import seedu.reserve.model.reservation.Reservation;
 import seedu.reserve.testutil.EditReservationDescriptorBuilder;
 import seedu.reserve.testutil.ReservationBuilder;
@@ -202,6 +204,29 @@ public class EditCommandTest {
 
         // Assert that the command fails with the correct error message
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_UNABLE_TO_EDIT_PAST_RESERVATION);
+    }
+
+    
+    @Test
+    public void execute_editPastReservationName_success() {
+        Reservation pastReservation = new ReservationBuilder().withDateTime("2022-01-01 1200").build();
+        model.addReservation(pastReservation);
+
+        EditCommand.EditReservationDescriptor descriptor = new EditReservationDescriptorBuilder()
+                .withName(VALID_NAME_BOB)
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_RESERVATION, descriptor);
+
+        Reservation editedReservation = new ReservationBuilder(pastReservation).withName(VALID_NAME_BOB).build();
+
+        String expectedMessage = "Warning: You modified a past reservation!\n"
+                + String.format(EditCommand.MESSAGE_EDIT_RESERVATION_SUCCESS, Messages.format(editedReservation));
+
+        Model expectedModel = new ModelManager(new ReserveMate(model.getReserveMate()), new UserPrefs());
+        expectedModel.setReservation(pastReservation, editedReservation);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+
     }
 
     @Test

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -3,7 +3,6 @@ package seedu.reserve.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.reserve.logic.commands.CommandTestUtil.DESC_BOB;
@@ -37,7 +36,6 @@ import seedu.reserve.model.Model;
 import seedu.reserve.model.ModelManager;
 import seedu.reserve.model.ReserveMate;
 import seedu.reserve.model.UserPrefs;
-import seedu.reserve.model.reservation.DateTime;
 import seedu.reserve.model.reservation.Reservation;
 import seedu.reserve.testutil.EditReservationDescriptorBuilder;
 import seedu.reserve.testutil.ReservationBuilder;
@@ -206,7 +204,6 @@ public class EditCommandTest {
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_UNABLE_TO_EDIT_PAST_RESERVATION);
     }
 
-    
     @Test
     public void execute_editPastReservationName_success() {
         Reservation pastReservation = new ReservationBuilder().withDateTime("2022-01-01 1200").build();

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -201,7 +201,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_RESERVATION, descriptor);
 
         // Assert that the command fails with the correct error message
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_FUTURE_RESERVATION_REQUIRED);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_UNABLE_TO_EDIT_PAST_RESERVATION);
     }
 
     @Test
@@ -212,7 +212,7 @@ public class EditCommandTest {
             .withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY)
             .withDiners(VALID_DINERS_AMY)
-            .withDateTime(LocalDateTime.now().plusDays(1).format(FORMATTER))
+            .withDateTime(LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.HOURS).format(FORMATTER))
             .withOccasions(VALID_OCCASION_BIRTHDAY)
             .build();
 
@@ -238,23 +238,6 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
-    @Test
-    public void execute_clearOccasionsFromPastReservation_failure() {
-        // Create a past reservation with an occasion
-        Reservation pastReservationWithOccasion = new ReservationBuilder()
-            .withDateTime("2020-01-01 1200") // Past date
-            .withOccasions(VALID_OCCASION_BIRTHDAY)
-            .build();
-
-        model.setReservation(model.getFilteredReservationList().get(0), pastReservationWithOccasion);
-
-        EditCommand.EditReservationDescriptor descriptor = new EditReservationDescriptorBuilder()
-            .withOccasions().build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_RESERVATION, descriptor);
-
-        // The command should fail because we can't edit past reservations
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_FUTURE_RESERVATION_REQUIRED);
-    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
@@ -179,6 +179,29 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseEditedDateTime_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseEditedDateTime((String) null));
+    }
+
+    @Test
+    public void parseEditedDateTime_invalidValue_throwsParseException() {
+        assertThrows(IllegalArgumentException.class, () -> ParserUtil.parseEditedDateTime(INVALID_DATETIME));
+    }
+
+    @Test
+    public void parseEditedDateTime_validValueWithoutWhitespace_returnsDateTime() throws Exception {
+        DateTime expectedDateTime = new DateTime(VALID_DATETIME);
+        assertEquals(expectedDateTime, ParserUtil.parseEditedDateTime(VALID_DATETIME));
+    }
+
+    @Test
+    public void parseEditedDateTime_validValueWithWhitespace_returnsTrimmedDateTime() throws Exception {
+        String dateTimeWithWhitespace = WHITESPACE + VALID_DATETIME + WHITESPACE;
+        DateTime expectedDateTime = new DateTime(VALID_DATETIME);
+        assertEquals(expectedDateTime, ParserUtil.parseEditedDateTime(dateTimeWithWhitespace));
+    }
+
+    @Test
     public void parseDateTimeFilter_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseDateTimeFilter(null));
     }
@@ -203,6 +226,7 @@ public class ParserUtilTest {
         DateTime expectedDateTime = ParserUtil.parseDateTimeFilter(dateTimeWithWhitespace);
         assertEquals(expectedDateTime, ParserUtil.parseDateTimeFilter(dateTimeWithWhitespace));
     }
+
 
     @Test
     public void parseOccasion_null_throwsNullPointerException() {

--- a/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
@@ -8,6 +8,7 @@ import static seedu.reserve.testutil.Assert.assertThrows;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -155,6 +156,9 @@ public class DateTimeTest {
         assertTrue(DateTime.isValidEditedDateTime(yesterdayDateTime, yesterdayDateTime));
         assertThrows(CommandException.class, () -> DateTime.isValidEditedDateTime(dayBeforeYesterdayDateTime,
                 yesterdayDateTime));
+
+        assertThrows(IllegalArgumentException.class, () -> DateTime
+                .isValidEditedDateTime(DateTime.fromFileString(INVALID_DATE_TIME_FORMAT_STR), yesterdayDateTime));
 
         // Future reservation: Can edit freely if constraints met
         assertTrue(DateTime.isValidEditedDateTime(tomorrowDateTime, tomorrowDateTime));

--- a/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
@@ -8,7 +8,6 @@ import static seedu.reserve.testutil.Assert.assertThrows;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
+++ b/src/test/java/seedu/reserve/model/reservation/DateTimeTest.java
@@ -12,6 +12,7 @@ import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.reserve.logic.commands.exceptions.CommandException;
 
 public class DateTimeTest {
 
@@ -25,6 +26,7 @@ public class DateTimeTest {
     private String formattedYesterdayDateTime;
     private String formattedTomorrowDateTime;
     private String formattedDayAfterDateTime;
+    private String formattedDayBeforeYesterdayDateTime;
 
     /**
      * Helper method to generate a formatted date string based on the current date and time.
@@ -63,6 +65,7 @@ public class DateTimeTest {
     @BeforeEach
     public void setUp() {
         formattedYesterdayDateTime = getFormattedDateTime(-1);
+        formattedDayBeforeYesterdayDateTime = getFormattedDateTime(-2);
         formattedTomorrowDateTime = getFormattedDateTime(1);
         formattedDayAfterDateTime = getFormattedDateTime(2);
     }
@@ -128,5 +131,22 @@ public class DateTimeTest {
         assertTrue(startDate.isBetween(startDate, endDate));
         assertTrue(endDate.isBetween(startDate, endDate));
     }
+
+    @Test
+    public void isValidEditedDateTime() throws CommandException {
+        // Past reservation: Can edit details but NOT the date-time
+        DateTime dayBeforeYesterdayDateTime = DateTime.fromFileString(formattedDayBeforeYesterdayDateTime);
+        DateTime yesterdayDateTime = DateTime.fromFileString(formattedYesterdayDateTime);
+        DateTime tomorrowDateTime = new DateTime(formattedTomorrowDateTime);
+
+        assertTrue(DateTime.isValidEditedDateTime(yesterdayDateTime, yesterdayDateTime));
+        assertThrows(CommandException.class, () -> DateTime.isValidEditedDateTime(dayBeforeYesterdayDateTime,
+                yesterdayDateTime));
+
+        // Future reservation: Can edit freely if constraints met
+        assertTrue(DateTime.isValidEditedDateTime(tomorrowDateTime, tomorrowDateTime));
+        assertFalse(DateTime.isValidEditedDateTime(yesterdayDateTime, tomorrowDateTime)); // Cannot move future to past
+    }
+
 
 }


### PR DESCRIPTION
Previously, users were not allowed to edit past reservations. This restriction has now been relaxed to allow users to modify reservation details, except for the date-time.

The original constraint prevented users from making any changes to past reservations, which was too restrictive.

Changes Implemented
- Users can now edit details of past reservations (e.g., number of diners, customer information).
- Users cannot modify the date-time of past reservations.
- Future reservations can still be edited, but they must meet the usual date-time constraints.
- A warning message is shown when editing past reservations.


This is the original data.
![image](https://github.com/user-attachments/assets/ab8be5e3-747b-4c92-9b00-5135600fd2ed)

`edit 1 x/2 n/John Doe` - successfully edit, warning message shown.
![image](https://github.com/user-attachments/assets/d80a38ca-049f-4c29-bbce-c77baa608427)

`edit 1 d/2025-05-05 1000` - fail to edit to future date .
![image](https://github.com/user-attachments/assets/ef8d37a7-e2d4-449a-ae2f-a7f02b80e1a9)


`edit 2 d/2025-05-05 1000` - success, edit future reservation.
![image](https://github.com/user-attachments/assets/c93603be-4ed8-48f0-828e-966784df1c30)

`edit 2 d/2023-04-23 1900`, `edit 2 d/ 2030-05-05 1200` - invalid dates

![image](https://github.com/user-attachments/assets/7db4f7cc-39a2-4ac0-82a6-16a4d6bc359c)


