### PR TITLE
Branch remove edit constraint

### DIFF
--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -58,7 +58,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_RESERVATION_SUCCESS = "Edited Reservation:\n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_EDIT_PAST_RESERVATION_WARNING = "Warning: You modified a past reservation!\n";
+    public static final String MESSAGE_EDIT_RESERVATION_WARNING = "Warning: You modified a past reservation!\n";
     public static final String MESSAGE_CANNOT_CHANGE_FUTURE_TO_PAST =
             "You cannot change a future reservation date to a past date.\n";
 
@@ -102,7 +102,7 @@ public class EditCommand extends Command {
         Reservation editedReservation = createEditedReservation(reservationToEdit, editReservationDescriptor);
 
         if (isDateTimeBeforeCurrentTime(reservationToEdit.getDateTime())) {
-            out = MESSAGE_EDIT_PAST_RESERVATION_WARNING;
+            out = MESSAGE_EDIT_RESERVATION_WARNING;
         } else {
             if (!DateTime.isValidDateTime(editedReservation.getDateTime().toString())
                     && isDateTimeBeforeCurrentTime(editedReservation.getDateTime())) {

--- a/src/main/java/seedu/reserve/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/reserve/logic/commands/EditCommand.java
@@ -104,8 +104,11 @@ public class EditCommand extends Command {
         if (isDateTimeBeforeCurrentTime(reservationToEdit.getDateTime())) {
             out = MESSAGE_EDIT_PAST_RESERVATION_WARNING;
         } else {
-            if (!DateTime.isValidDateTime(editedReservation.getDateTime().toString())) {
+            if (!DateTime.isValidDateTime(editedReservation.getDateTime().toString())
+                    && isDateTimeBeforeCurrentTime(editedReservation.getDateTime())) {
                 throw new CommandException(MESSAGE_CANNOT_CHANGE_FUTURE_TO_PAST + DateTime.MESSAGE_CONSTRAINTS);
+            } else if (!DateTime.isValidDateTime(editedReservation.getDateTime().toString())) {
+                throw new CommandException(DateTime.MESSAGE_CONSTRAINTS);
             }
         }
 

--- a/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/reserve/logic/parser/EditCommandParser.java
@@ -73,7 +73,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_DATE_TIME).isPresent()) {
             editReservationDescriptor
-                    .setDateTime(ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE_TIME).get()));
+                    .setDateTime(ParserUtil.parseEditedDateTime(argMultimap.getValue(PREFIX_DATE_TIME).get()));
         }
         parseOccasionsForEdit(argMultimap.getAllValues(PREFIX_OCCASION))
             .ifPresent(editReservationDescriptor::setOccasions);

--- a/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
@@ -184,6 +184,21 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code dateTime} is invalid.
      */
+    public static DateTime parseEditedDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+        if (!DateTime.isValidFileInputDateTime(trimmedDateTime)) {
+            throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
+        }
+        return DateTime.fromEditedDateString(trimmedDateTime);
+    }
+
+    /**
+     * Parses a {@code String dateTime} into a {@code DateTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code dateTime} is invalid.
+     */
     public static DateTime parseDateTimeFree(String dateTime) throws ParseException {
         requireNonNull(dateTime);
         String trimmedDateTime = dateTime.trim();

--- a/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/reserve/logic/parser/ParserUtil.java
@@ -190,7 +190,7 @@ public class ParserUtil {
         if (!DateTime.isValidFileInputDateTime(trimmedDateTime)) {
             throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
         }
-        return DateTime.fromEditedDateString(trimmedDateTime);
+        return DateTime.fromFileString(trimmedDateTime);
     }
 
     /**

--- a/src/main/java/seedu/reserve/model/reservation/DateTime.java
+++ b/src/main/java/seedu/reserve/model/reservation/DateTime.java
@@ -63,18 +63,6 @@ public class DateTime implements Comparable<DateTime> {
     }
 
     /**
-     * Constructs a {@code DateTime} from a string input without validation.
-     *
-     * @param dateTime A date-time string.
-     * @return A DateTime object if the string is valid, otherwise null.
-     */
-    public static DateTime fromEditedDateString(String dateTime) {
-        requireNonNull(dateTime);
-        checkArgument(isValidFileInputDateTime(dateTime), MESSAGE_CONSTRAINTS);
-        return new DateTime(LocalDateTime.parse(dateTime, FORMATTER));
-    }
-
-    /**
      * Returns true if a given string is a valid date-time in the format YYYY-MM-DD HHmm and after current date-time.
      */
     public static boolean isValidDateTime(String test) {

--- a/src/main/java/seedu/reserve/model/reservation/DateTime.java
+++ b/src/main/java/seedu/reserve/model/reservation/DateTime.java
@@ -63,6 +63,18 @@ public class DateTime implements Comparable<DateTime> {
     }
 
     /**
+     * Constructs a {@code DateTime} from a string input without validation.
+     *
+     * @param dateTime A date-time string.
+     * @return A DateTime object if the string is valid, otherwise null.
+     */
+    public static DateTime fromEditedDateString(String dateTime) {
+        requireNonNull(dateTime);
+        checkArgument(isValidFileInputDateTime(dateTime), MESSAGE_CONSTRAINTS);
+        return new DateTime(LocalDateTime.parse(dateTime, FORMATTER));
+    }
+
+    /**
      * Returns true if a given string is a valid date-time in the format YYYY-MM-DD HHmm and after current date-time.
      */
     public static boolean isValidDateTime(String test) {

--- a/src/main/java/seedu/reserve/model/reservation/Email.java
+++ b/src/main/java/seedu/reserve/model/reservation/Email.java
@@ -58,7 +58,7 @@ public class Email {
         String domain = test.substring(domainIndex + 1);
         String locale = test.substring(0, domainIndex);
 
-        if (locale.length() > 63) {
+        if (locale.length() > 64) {
             return false;
         }
 

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -36,6 +36,7 @@ import seedu.reserve.model.Model;
 import seedu.reserve.model.ModelManager;
 import seedu.reserve.model.ReserveMate;
 import seedu.reserve.model.UserPrefs;
+import seedu.reserve.model.reservation.DateTime;
 import seedu.reserve.model.reservation.Reservation;
 import seedu.reserve.testutil.EditReservationDescriptorBuilder;
 import seedu.reserve.testutil.ReservationBuilder;
@@ -200,8 +201,19 @@ public class EditCommandTest {
                 .build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_RESERVATION, descriptor);
 
+
+        Reservation editedReservation = new ReservationBuilder(pastReservation)
+                .withDateTime(LocalDateTime.now().plusDays(29).truncatedTo(ChronoUnit.HOURS).format(FORMATTER)).build();
+
+
+        Model expectedModel = new ModelManager(new ReserveMate(model.getReserveMate()),
+                new UserPrefs());
+        expectedModel.setReservation(pastReservation, editedReservation);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PAST_RESERVATION_WARNING
+                        + EditCommand.MESSAGE_EDIT_RESERVATION_SUCCESS, Messages.format(editedReservation));
         // Assert that the command fails with the correct error message
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_FUTURE_RESERVATION_REQUIRED);
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -239,23 +251,27 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_clearOccasionsFromPastReservation_failure() {
-        // Create a past reservation with an occasion
-        Reservation pastReservationWithOccasion = new ReservationBuilder()
-            .withDateTime("2020-01-01 1200") // Past date
-            .withOccasions(VALID_OCCASION_BIRTHDAY)
-            .build();
+    public void execute_editFutureReservationToPastTime_failure() {
+        // Create a future reservation
+        Reservation futureReservation = new ReservationBuilder()
+                .withDateTime(LocalDateTime.now().plusDays(10)
+                        .truncatedTo(ChronoUnit.HOURS).format(FORMATTER)) // Future date
+                .build();
 
-        model.setReservation(model.getFilteredReservationList().get(0), pastReservationWithOccasion);
+        model.addReservation(futureReservation);
+        Index targetIndex = INDEX_FIRST_RESERVATION;
 
+        // Create descriptor with past date
         EditCommand.EditReservationDescriptor descriptor = new EditReservationDescriptorBuilder()
-            .withOccasions().build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_RESERVATION, descriptor);
+                .withEditedDateTime("2022-01-01 1200") // Past date
+                .build();
 
-        // The command should fail because we can't edit past reservations
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_FUTURE_RESERVATION_REQUIRED);
+        EditCommand editCommand = new EditCommand(targetIndex, descriptor);
+
+        // Expect failure due to past reservation edit restriction
+        assertCommandFailure(editCommand, model,
+                EditCommand.MESSAGE_CANNOT_CHANGE_FUTURE_TO_PAST + DateTime.MESSAGE_CONSTRAINTS);
     }
-
     @Test
     public void equals() {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_RESERVATION, DESC_AMY);

--- a/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/reserve/logic/commands/EditCommandTest.java
@@ -210,7 +210,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setReservation(pastReservation, editedReservation);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PAST_RESERVATION_WARNING
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_RESERVATION_WARNING
                         + EditCommand.MESSAGE_EDIT_RESERVATION_SUCCESS, Messages.format(editedReservation));
         // Assert that the command fails with the correct error message
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
@@ -266,7 +266,7 @@ public class ParserUtilTest {
     @Test
     public void parseEditedDateTime_validInput_success() throws ParseException {
         String validDateTime = "2025-12-31 1800";
-        DateTime expectedDateTime = DateTime.fromEditedDateString(validDateTime);
+        DateTime expectedDateTime = DateTime.fromFileString(validDateTime);
         assertEquals(expectedDateTime, ParserUtil.parseEditedDateTime(validDateTime));
     }
 

--- a/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/reserve/logic/parser/ParserUtilTest.java
@@ -264,6 +264,30 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseEditedDateTime_validInput_success() throws ParseException {
+        String validDateTime = "2025-12-31 1800";
+        DateTime expectedDateTime = DateTime.fromEditedDateString(validDateTime);
+        assertEquals(expectedDateTime, ParserUtil.parseEditedDateTime(validDateTime));
+    }
+
+    @Test
+    public void parseEditedDateTime_invalidInput_throwsParseException() {
+        String invalidDateTime = "30-12-2025 10"; // Wrong format
+        assertThrows(ParseException.class, () -> ParserUtil.parseEditedDateTime(invalidDateTime));
+    }
+
+    @Test
+    public void parseEditedDateTime_emptyInput_throwsParseException() {
+        String emptyDateTime = "";
+        assertThrows(ParseException.class, () -> ParserUtil.parseEditedDateTime(emptyDateTime));
+    }
+
+    @Test
+    public void parseEditedDateTime_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseEditedDateTime(null));
+    }
+
+    @Test
     public void parseDeleteArgs_validInputWithSpacesWithConfirmation_success() throws ParseException {
         String input = "1             cfm";
         Pair<Index, Boolean> result = ParserUtil.parseDeleteArgs(input);

--- a/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
+++ b/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
@@ -82,6 +82,12 @@ public class EditReservationDescriptorBuilder {
         return this;
     }
 
+    public EditReservationDescriptorBuilder withEditedDateTime(String dateTime) {
+        descriptor.setDateTime(DateTime.fromEditedDateString(dateTime));
+        return this;
+    }
+
+
     /**
      * Parses the {@code occasions} into a {@code Set<Occasion>} and set it to the {@code EditReservationDescriptor}
      * that we are building.

--- a/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
+++ b/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
@@ -82,6 +82,9 @@ public class EditReservationDescriptorBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Address} of the {@code EditReservationDescriptor} that we are building.
+     */
     public EditReservationDescriptorBuilder withEditedDateTime(String dateTime) {
         descriptor.setDateTime(DateTime.fromEditedDateString(dateTime));
         return this;

--- a/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
+++ b/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
@@ -86,7 +86,7 @@ public class EditReservationDescriptorBuilder {
      * Sets the {@code DateTime} of the {@code EditReservationDescriptor} that we are building.
      */
     public EditReservationDescriptorBuilder withEditedDateTime(String dateTime) {
-        descriptor.setDateTime(DateTime.fromEditedDateString(dateTime));
+        descriptor.setDateTime(DateTime.fromFileString(dateTime));
         return this;
     }
 

--- a/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
+++ b/src/test/java/seedu/reserve/testutil/EditReservationDescriptorBuilder.java
@@ -83,7 +83,7 @@ public class EditReservationDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code Address} of the {@code EditReservationDescriptor} that we are building.
+     * Sets the {@code DateTime} of the {@code EditReservationDescriptor} that we are building.
      */
     public EditReservationDescriptorBuilder withEditedDateTime(String dateTime) {
         descriptor.setDateTime(DateTime.fromEditedDateString(dateTime));


### PR DESCRIPTION
Previously, users were not allowed to edit past reservations. This restriction has now been relaxed to allow users to modify reservation details, except for the date-time.

The original constraint prevented users from making any changes to past reservations, which was too restrictive.

Changes Implemented:
- Users can now edit details of past reservations (e.g., number of diners, customer information).
- Users can modify the date-time of past reservations.
- Future reservations cannot be changed to past dates.
- A warning message is displayed when editing past reservations.

This is the original data.
![image](https://github.com/user-attachments/assets/7d0bcfea-f64f-4561-98a0-4fa90c9a5f5a)

`edit 1 x/2 n/John Doe` - successfully edit, warning message shown.
![image](https://github.com/user-attachments/assets/303ebbb0-043e-430c-aff7-15b9a8339b21)

`edit 1 d/2025-05-05 1000 `- edit past reservation future date success.
![image](https://github.com/user-attachments/assets/64b4d402-c60a-4bef-88ee-c9ac7b1fbd83)

`edit 2 d/2025-05-05 1000` - success, edit future reservation.
![image](https://github.com/user-attachments/assets/b1df0514-f9d3-4e9e-ad83-c0e49547445f)

`edit 2 d/2023-04-23 1900` - invalid dates fail past date
![image](https://github.com/user-attachments/assets/ba817332-5636-4f5a-9b50-85ee5f78fb7b)

Fix #245 